### PR TITLE
Enhanced checks architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ This changelog catalogs all notable changes made to the project. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Releases are 
 versioned in accordance with [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Enhanced
+- The checks subsystem has been rearchitected to streamline the development of
+checks and provide a better operational experience for running and debugging checks.
+
+### Added
+- `servo run --check` will run all configured checks before starting the servo runloop.
+- `servo check` now supports filtering by name, id, and tags. Failure mode handling is configurable via `--halt-on-failed=[requirement,check,never]`
+
 ## [0.5.1] - 2020-08-23
 
 ### Removed

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,6 +36,7 @@ version = "0.13.0"
 reference = "9aefec8dd301bf8c4a4e03a22fb4ec64c2b479cf"
 type = "git"
 url = "https://github.com/Martiusweb/asynctest.git"
+
 [[package]]
 category = "dev"
 description = "Atomic file writes."
@@ -527,6 +528,18 @@ testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "
 
 [[package]]
 category = "dev"
+description = "Wrap tests with fixtures in freeze_time"
+name = "pytest-freezegun"
+optional = false
+python-versions = "*"
+version = "0.4.2"
+
+[package.dependencies]
+freezegun = ">0.3"
+pytest = ">=3.0.0"
+
+[[package]]
+category = "dev"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 name = "pytest-mock"
 optional = false
@@ -754,7 +767,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "5bca495112c13069f35c6927bbc07a3abd8cce2ba56fe857fd78de29b227286d"
+content-hash = "253b923591681116041a5972a02b954ef23bf10327b51ae3d6289228a70d4ae5"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -1030,6 +1043,10 @@ pytest-asyncio = [
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
     {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+]
+pytest-freezegun = [
+    {file = "pytest-freezegun-0.4.2.zip", hash = "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949"},
+    {file = "pytest_freezegun-0.4.2-py2.py3-none-any.whl", hash = "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"},
 ]
 pytest-mock = [
     {file = "pytest-mock-3.3.0.tar.gz", hash = "sha256:1d146a6e798b9e6322825e207b4e0544635e679b69253e6e01a221f45945d2f6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ freezegun = "^0.3.15"
 asynctest = {git = "https://github.com/Martiusweb/asynctest.git", rev = "py3.8"}
 respx = "^0.11.2"
 kubetest = "^0.8.1"
+pytest-freezegun = "^0.4.2"
 
 [tool.poetry.scripts]
 servo = "servo.entry_points:run_cli"

--- a/servo/checks.py
+++ b/servo/checks.py
@@ -1,18 +1,274 @@
 import asyncio
-from typing import List
-from pydantic import BaseModel
+
+from datetime import datetime
+from hashlib import blake2b
+from inspect import Signature, isclass
+from typing import Callable, Generator, List, Optional, Pattern, Sequence, Set, TypeVar, Tuple, Union, get_origin, get_args
+
+from pydantic import BaseModel, Extra, StrictStr, validator, constr
 from servo.configuration import BaseConfiguration
-from servo.types import Check
+from servo.types import Any, Duration
+from servo.utilities.inspect import get_instance_methods
+
+import loguru
+from loguru import logger as default_logger
 
 
 __all__ = [
-    "BaseChecks"
+    "BaseChecks",
+    "Check",
+    "CheckHandlerResult"
 ]
+
+
+CheckHandlerResult = Union[bool, str, Tuple[bool, str], None]
+CheckHandler = TypeVar("CheckHandler", bound=Callable[..., CheckHandlerResult])
+CHECK_HANDLER_SIGNATURE = Signature(return_annotation=CheckHandlerResult)
+
+Tag = constr(strip_whitespace=True, min_length=1, max_length=32, regex="^([0-9a-z\\.-])*$")
+
+
+class Check(BaseModel):
+    """
+    Check objects represent the status of required runtime conditions.
+
+    A check is an atomic verification that a particular aspect
+    of a configuration is functional and ready for deployment. Connectors can
+    have an arbitrary number of prerequisites and options that need to be
+    checked within the runtime environment.
+
+    Checks are used to verify the correctness of servo configuration before
+    starting optimization and report on health and readiness during operation.
+    """
+
+    name: StrictStr
+    """An arbitrary descriptive name of the condition being checked.
+    """
+
+    id: StrictStr = None
+    """A short identifier for the check. Generated automatically if unset.
+    """
+
+    description: Optional[StrictStr]
+    """An optional detailed description about the condition being checked.
+    """
+
+    required: bool = False
+    """
+    Indicates if the check is a pre-condition for subsequent checks.
+
+    Required state is used to halt the execution of a sequence of checks
+    that are part of a `Checks` object. For example, given a connector
+    that connects to a remote service such as a metrics provider, you
+    may wish to check that each metrics query is well formed and returns
+    results. In order for any of the query checks to succeed, the servo
+    must be able to connect to the service. During failure modes such as
+    network partitions, service outage, or simple configuration errors
+    this can result in an arbitrary number of failing checks with an 
+    identical root cause that make it harder to identify the issue.
+    Required checks allow you to declare these sorts of pre-conditions
+    and the servo will test them before running any dependent checks,
+    ensuring that you get a single failure that identifies the root cause.
+
+    For checks that do not belong to a `Checks` object, required is
+    purely advisory metadata and is ignored by the servo.
+    """
+
+    tags: Optional[Set[Tag]]
+    """
+    An optional set of tags for filtering checks.
+
+    Tags are strings between 1 and 32 characters in length and may contain 
+    only lowercase alphanumeric characters, hyphens '-', and periods '.'.
+    """
+
+    success: Optional[bool]
+    """
+    Indicates if the condition being checked was met or not. 
+    """
+
+    message: Optional[StrictStr]
+    """
+    An optional message describing the outcome of the check.
+
+    The message is presented to users and should be informative. Long
+    messages may be truncated on display.
+    """
+
+    exception: Optional[Exception]
+    """
+    An optional exception encountered while running the check.
+
+    When checks encounter an exception condition, it is recommended to
+    store the exception so that diagnostic metadata such as the stack trace 
+    can be presented to the user.
+    """
+    
+    created_at: datetime = None
+    """When the check was created (set automatically).
+    """
+
+    run_at: Optional[datetime]
+    """An optional timestamp indicating when the check was run.
+    """
+
+    runtime: Optional[Duration]
+    """An optional duration indicating how long it took for the check to run.
+    """
+
+    @classmethod
+    def run(cls, name: str, *, handler: CheckHandler, description: Optional[str] = None) -> 'Check':
+        """Runs a check handler and returns a Check object reporting the outcome.
+
+        This method is useful for quickly implementing checks in connectors that
+        do not have enough checkable conditions to warrant implementing a `Checks`
+        subclass.
+
+        Args:
+            name: A name for the check being run.
+            handler: The callable to run to perform the check. Must accept no arguments
+                and return a `bool`, `str`, `Tuple[bool, str]`, or `None`. Boolean values
+                indicate success or failure and string values are assigned to the `message`
+                attribute of the Check object returned. Exceptions are rescued, mark the check
+                as a failure, and assigned to the `exception` attribute.
+            description: An optional detailed description about the check being run.
+
+        Returns:
+            A check object reporting the outcome of running the handler.
+        """
+        check = Check(name=name, description=description)
+        run_check_handler(check, handler)
+        return check
+
+    @property
+    def failed(self) -> bool:
+        """
+        Indicates if the check was unsuccessful.
+        """
+        return not self.success
+
+    @validator("created_at", pre=True, always=True)
+    @classmethod
+    def _set_created_at_now(cls, v):
+        return v or datetime.now()
+    
+    @validator("id", pre=True, always=True)
+    @classmethod
+    def _generated_id(cls, v,  values):        
+        return v or blake2b(values["name"].encode('utf-8'), digest_size=4).hexdigest()
+    
+    class Config:
+        validate_assignment = True
+        arbitrary_types_allowed = True
+        json_encoders = {
+            Exception: lambda v: repr(v),
+        }
+
+
+def run_check_handler(check: Check, handler: CheckHandler, *args):
+    """Runs a check handler and records the result into a Check object.
+
+    Args:
+        check: The check to record execution results.
+        handler: A callable handler to perform the check.
+
+    Raises:
+        ValueError: Raised if an invalid value is returned by the handler.
+    """
+    check.run_at = datetime.now()
+    try:
+        result = handler(*args)
+        check.success = True
+        
+        if isinstance(result, str):
+            check.message = result
+        elif isinstance(result, bool):
+            check.success = result
+        elif isinstance(result, tuple):
+            check.success, check.message = result
+        elif result is None:
+            pass
+        else:
+            raise ValueError(f"check method returned unexpected value of type \"{result.__class__.__name__}\"")
+
+    except Exception as e:
+        check.success = False
+        check.exception = e
+        check.message = f"caught exception: {repr(e)}"
+
+    check.runtime = Duration(datetime.now() - check.run_at)
+
+CheckRunner = TypeVar("CheckRunner", bound=Callable[..., Check])
+
+def check(
+    name: str, 
+    *, 
+    description: Optional[str] = None,
+    id: Optional[str] = None,
+    required: bool = False,
+    tags: Optional[List[str]] = None) -> Callable[[CheckHandler], CheckRunner]:
+    """
+    Transforms a function or method into a check.
+    
+    Checks are used to test the availability, readiness, and health of resources and
+    services that used during optimization. The `Check` class models the status of a
+    check that has been run. The `check` function is a decorator that transforms a
+    function or method that returns a `bool`, `str`, `Tuple[bool, str]`, or `None` 
+    into a check function or method.
+
+    The decorator requires a `name` parameter to identify the check as well as an optional
+    informative `description`, an `id` for succintly referencing the check, and a `required`
+    boolean value that determines if a failure with halt execution of subsequent checks.
+    The body of the decorated function is used to perform the business logic of running
+    the check. The decorator wraps the original function body into a handler that runs the
+    check and marshalls the value returned or exception caught into a `Check` representation.
+    The `run_at` and `runtime` properties are automatically set, providing execution timing of
+    the check. The signature of the transformed function is `() -> Check`.
+
+    Args:
+        name: Human readable name of the check.
+        description: Optional additional details about the check.
+        id: A short identifier for referencing the check (e.g. from the CLI interface).
+        required: When True, failure of the check will halt execution of subsequent checks.
+        tags: An optional list of tags for filtering checks. Tags may contain only lowercase
+            alphanumeric characters, hyphens '-', and periods '.'.
+    
+    Returns:
+        A decorator function for transforming a function into a check.
+    
+    Raises:
+        TypeError: Raised if the signature of the decorated function is incompatible.
+    """
+    def decorator(fn: CheckHandler) -> CheckRunner:
+        validate_check_handler(fn)
+        __check__ = Check(
+            name=name, 
+            description=description, 
+            id=(id or fn.__name__),
+            required=required,
+            tags=tags,
+        )
+
+        # note: use a default value for self to wrap funcs & methods
+        def run_check(self: Optional[Any] = None) -> Check:
+            check = __check__.copy()
+            args = [self] if self else []
+            run_check_handler(check, fn, *args)
+            return check
+
+        run_check.__check__ = __check__
+        return run_check
+
+    return decorator
+
+
+CHECK_SIGNATURE = Signature(return_annotation=Check)
+CHECK_SIGNATURE_ANNOTATED = Signature(return_annotation='Check')
 
 
 class BaseChecks(BaseModel):
     """
-    Base class for collections of Servo Connector check implementations.
+    Base class for collections of Check objects.
 
     This is a convenience class for quickly and cleanly implementing checks
     for a connector. A check is an atomic verification that a particular aspect
@@ -39,36 +295,224 @@ class BaseChecks(BaseModel):
     Args:
         config: The configuration object for the connector being checked.
     """
+    
     config: BaseConfiguration
+    """The configuration object for the connector being checked.
+    """
 
     @classmethod
-    async def run(cls, config: BaseConfiguration, *, all: bool = False) -> List[Check]:
+    async def check(cls, 
+        config: BaseConfiguration, 
+        *, 
+        logger: 'loguru.Logger' = default_logger,
+        name: Union[None, str, Sequence[str], Pattern[str]] = None,
+        id: Union[None, str, Sequence[str], Pattern[str]] = None,
+        tags: Optional[Set[str]] = None,
+        all: bool = False
+    ) -> List[Check]:
         """
-        Run all checks and return a list of Check objects reflecting the results.
+        Runs checks and returns a list of Check objects reflecting the results.
 
         Checks are implemented as instance methods prefixed with `check_` that return a `Check`
         object. Please refer to the `BaseChecks` class documentation for details.
 
+        Keyword arguments are used to filter the set of checks to be run. See the documentation
+        on the `run` instance method for details on filtering.
+
         Args:
-            all: When True, all checks are run regardless of previous failures or being required.
+            config: The connector configuration to initialize the checks instance with.
+            logger: 
+            name: A name, sequence of names, or regex pattern for selecting checks by name.
+            id:  A name, sequence of names, or regex pattern for selecting checks by name.
+            tags: A set of tags for selecting checks to be run. Checks matching any tag in the set
+                are selected.
+            all: When True, continue running checks even if a required check has failed.
         
         Returns:
-            A list of `Check` objects that reflect the outcomes of the checks executed.
+            A list of `Check` objects that reflect the outcome of the checks executed.
         """
-        checker = cls(config=config)
-        checks: List[Check] = []
-        for attr in dir(checker):
-            if not attr.startswith("check_"):
-                continue
+        return await cls(config, logger=logger).run(name=name, id=id, tags=tags, all=all)
 
-            method = getattr(checker, attr)
-            if callable(method):
-                check = (
-                    await method() if asyncio.iscoroutinefunction(method)
-                    else method()
+    async def run(self, 
+        *, 
+        name: Union[None, str, Sequence[str], Pattern[str]] = None,
+        id: Union[None, str, Sequence[str], Pattern[str]] = None,
+        tags: Optional[Set[str]] = None,
+        all: bool = False
+    ) -> List[Check]:
+        """
+        Runs checks and returns the results.
+
+        Specific checks can be targetted for execution using the metadata attributes of `name`,
+        `id`, and `tags`. Metadata filters are evaluated using AND semantics. Names and ids
+        are matched case-sensitively. Tags are always lowercase. Names and ids can be targetted 
+        using regular expression patterns. Checks are evaluated and returned in method definition
+        order.
+
+        Args:
+            name: A name, sequence of names, or regex pattern for selecting checks by name.
+            id:  A name, sequence of names, or regex pattern for selecting checks by name.
+            tags: A set of tags for selecting checks to be run. Checks matching any tag in the set
+                are selected.
+            all: When True, continue running checks even if a required check has failed.
+        
+        Returns:
+            A list of checks that were run.
+        """
+
+        class Filter(BaseModel):
+            name: Union[None, str, Sequence[str], Pattern[str]] = None,
+            id: Union[None, str, Sequence[str], Pattern[str]] = None,
+            tags: Optional[Set[str]] = None
+
+            @property
+            def any(self) -> bool:
+                return not self.empty
+            
+            @property
+            def empty(self) -> bool:
+                return bool(
+                    self.name is None 
+                    and self.id is None 
+                    and self.tags is None
                 )
-                if not isinstance(check, Check):
-                    raise AssertionError(f"check implementations must return `Check` instances: `{attr}` returned `{check.__class__.__name__}`")
-                checks.append(check)                
+            
+            def matches(self, check: Check) -> bool:
+                if self.empty:
+                    return True
+
+                return (                    
+                    self._matches_name(check)
+                    and self._matches_id(check)
+                    and self._matches_tags(check)
+                )
+
+            def _matches_name(self, check: Check) -> bool:
+                return self._matches_str_attr(self.name, check.name)
+            
+            def _matches_id(self, check: Check) -> bool:
+                return self._matches_str_attr(self.id, check.id)
+            
+            def _matches_tags(self, check: Check) -> bool:
+                if self.tags is None:
+                    return True
+                
+                # exclude untagged checks if filtering by tag
+                if check.tags is None:
+                    return False
+                
+                # look for an intersection in our sets
+                return bool(self.tags.intersection(check.tags))
+            
+            def _matches_str_attr(
+                self, 
+                attr: Union[None, str, Sequence[str], Pattern[str]],
+                value: str
+            ) -> bool:
+                if attr is None:
+                    return True
+                elif isinstance(attr, str):
+                    return value == attr
+                elif isinstance(attr, Sequence):
+                    return value in attr
+                elif isinstance(attr, Pattern):
+                    return bool(attr.search(value))
+                else:
+                    raise ValueError(f"unexpected value of type \"{attr.__class__.__name__}\": {attr}")
+        
+            class Config:
+                arbitrary_types_allowed = True
+        
+        checks = []
+        filter = Filter(name=name, id=id, tags=tags)
+        for method_name, method in self.check_methods():
+            if filter.any:
+                spec = getattr(method, '__check__', None)
+                if not spec:
+                    self.logger.warning(f"filtering requested but encountered non-filterable check method \"{method_name}\"")
+                    continue
+                
+                if not filter.matches(spec):
+                    continue
+
+            check = (
+                await method() if asyncio.iscoroutinefunction(method)
+                else method()
+            )
+            if not isinstance(check, Check):
+                raise TypeError(f"check methods must return `Check` objects: `{method_name}` returned `{check.__class__.__name__}`")
+            
+            checks.append(check)
+
+            # halt if a required check has failed
+            if check.failed and check.required:
+                break
         
         return checks
+    
+    def check_methods(self) -> Generator[Tuple[str, CheckRunner], None, None]:
+        """
+        Enumerates all check methods and yields the check method names and callable instances 
+        in method definition order.
+
+        Check method names are prefixed with "check_", accept no parameters, and return a
+        `Check` object reporting the outcome of the check operation.
+        """
+        for name, method in get_instance_methods(self).items():
+            if not name.startswith(("_", "check_")):
+                raise ValueError(f'method names of Checks subtypes must start with "_" or "check_"')
+            
+            sig = Signature.from_callable(method)
+            if sig not in (CHECK_SIGNATURE, CHECK_SIGNATURE_ANNOTATED):
+                raise TypeError(f'invalid signature for method "{name}": expected {repr(CHECK_SIGNATURE)}, but found {repr(sig)}')
+            
+            yield (name, method)
+
+    
+    def __init__(self, config: BaseConfiguration, *, logger: 'loguru.Logger' = default_logger, **kwargs) -> None:
+        super().__init__(config=config, logger=logger, **kwargs)
+    
+    class Config:
+        arbitrary_types_allowed = True
+        extra = Extra.allow
+
+
+def validate_check_handler(fn: CheckHandler) -> None:
+    """
+    Validates that a function or method is usable as a check handler.
+
+    Check handlers accept no arguments and return a `bool`, `str`, 
+    `Tuple[bool, str]`, or `None`.
+
+    Args:
+        fn: The check handler to be validated.
+    
+    Raises:
+        TypeError: Raised if the handler function is invalid.
+    """
+    signature = Signature.from_callable(fn)
+    if len(signature.parameters) >= 1:
+        for param in signature.parameters.values():
+            if param.name == "self" and param.kind == param.POSITIONAL_OR_KEYWORD:
+                continue
+
+            raise TypeError(f"invalid check handler \"{fn.__name__}\": unexpected parameter \"{param.name}\" in signature {repr(signature)}, expected {repr(CHECK_HANDLER_SIGNATURE)}")
+
+    error = TypeError(f"invalid check handler \"{fn.__name__}\": incompatible return type annotation in signature {repr(signature)}, expected to match {repr(CHECK_HANDLER_SIGNATURE)}")
+    acceptable_types = set(get_args(CheckHandlerResult))
+    origin = get_origin(signature.return_annotation)
+    args = get_args(signature.return_annotation)
+    if origin is not None:
+        if origin == Union:
+            handler_types = set(args)
+            if handler_types - acceptable_types:
+                raise error
+        elif origin is tuple:
+            if args != (bool, str):
+                raise error
+        else:
+            raise error
+    else:
+        cls = signature.return_annotation if isclass(signature.return_annotation) else signature.return_annotation.__class__
+        if not cls in acceptable_types:
+            raise error

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -40,7 +40,7 @@ from servo.servo import (
     Servo,
     _connector_class_from_string
 )
-from servo.checks import Filter
+from servo.checks import Filter, HaltOnFailed
 from servo.runner import Runner
 from servo.types import *
 from servo.utilities import PreservedScalarString, commandify
@@ -982,7 +982,10 @@ class ServoCLI(CLI):
             ),
             tag: Optional[List[str]] = typer.Option(
                 False, "--tag", "-t", help="Filter by tag"
-            ),            
+            ),
+            halt_on: HaltOnFailed = typer.Option(
+                HaltOnFailed.requirement, "--halt-on-failed", "-h", help="Halt running checks on a failure condition",
+            ),
             verbose: bool = typer.Option(
                 False, "--verbose", "-v", help="Display verbose output"
             ),
@@ -1011,7 +1014,7 @@ class ServoCLI(CLI):
             constraints = dict(filter(lambda i: len(i[1]), dict(name=name, id=id, tags=tag).items()))
             filter_ = Filter(**constraints)
             results: List[EventResult] = sync(context.servo.dispatch_event(
-                Events.CHECK, filter_, include=connectors, 
+                Events.CHECK, filter_, include=connectors, halt_on=halt_on
             ))
 
             table = []

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -1033,7 +1033,7 @@ class ServoCLI(CLI):
                 
                 return v
 
-            args = dict(name=parse_re(name), id=parse_id(id), tags=tag)
+            args = dict(name=parse_re(name), id=parse_id(id), tags=parse_csv(tag))
             constraints = dict(filter(lambda i: bool(i[1]), args.items()))
             filter_ = Filter(**constraints)
             results: List[EventResult] = sync(context.servo.dispatch_event(
@@ -1066,7 +1066,7 @@ class ServoCLI(CLI):
                     checks: List[Check] = result.value
                     if not checks:
                         continue
-                    
+
                     success = True
                     errors = []
                     for check in checks:

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -31,15 +31,16 @@ from servo.assembly import (
 )
 from servo.connector import (
     BaseConnector, 
-    Optimizer,
-    _connector_class_from_string
+    Optimizer
 )
 from servo.events import EventHandler, EventResult, Preposition
 from servo.logging import logger, set_level as set_log_level
 from servo.servo import (
     Events,
     Servo,
+    _connector_class_from_string
 )
+from servo.checks import Filter
 from servo.runner import Runner
 from servo.types import *
 from servo.utilities import PreservedScalarString, commandify
@@ -1007,9 +1008,10 @@ class ServoCLI(CLI):
             else:
                 connectors = context.assembly.connectors
 
-            filters = dict(filter(lambda i: len(i[1]), dict(name=name, id=id, tags=tag).items()))
+            constraints = dict(filter(lambda i: len(i[1]), dict(name=name, id=id, tags=tag).items()))
+            filter_ = Filter(**constraints)
             results: List[EventResult] = sync(context.servo.dispatch_event(
-                Events.CHECK, include=connectors, **filters
+                Events.CHECK, filter_, include=connectors, 
             ))
 
             table = []

--- a/servo/connector.py
+++ b/servo/connector.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 import asyncio
 import abc
-import importlib
 import re
-from pathlib import Path
 from pkg_resources import EntryPoint, iter_entry_points
 from typing import (
     Any,
@@ -325,52 +323,6 @@ def _name_for_connector_class(cls: Type[BaseConnector]) -> Optional[str]:
         if name != "":
             return name
     return None
-
-
-def _connector_class_from_string(connector: str) -> Optional[Type[BaseConnector]]:
-    if not isinstance(connector, str):
-        return None
-
-    # Check for an existing class in the namespace
-    # FIXME: This symbol lookup doesn't seem solid
-    connector_class = globals().get(connector, None)
-    try:
-        connector_class = (
-            eval(connector) if connector_class is None else connector_class
-        )
-    except Exception:
-        pass
-    
-    if _validate_class(connector_class):
-        return connector_class
-
-    # Check if the string is an identifier for a connector
-    for connector_class in _connector_subclasses:
-        if connector == connector_class.__default_name__ or connector in [
-            connector_class.__name__,
-            connector_class.__qualname__,
-        ]:
-            return connector_class
-
-    # Try to load it as a module path
-    if "." in connector:
-        module_path, class_name = connector.rsplit(".", 1)
-        module = importlib.import_module(module_path)
-        if hasattr(module, class_name):
-            connector_class = getattr(module, class_name)
-            if _validate_class(connector_class):
-                return connector_class
-
-    return None
-
-def _validate_class(connector: type) -> bool:
-    if connector is None or not isinstance(connector, type):
-        return False
-
-    if not issubclass(connector, BaseConnector):
-        raise TypeError(f"{connector.__name__} is not a Connector subclass")
-
-    return True
 
 
 #####

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -34,6 +34,7 @@ from servo import (
     Duration,
     DurationProgress,
     Filter,
+    HaltOnFailed,
     License,
     Maturity,
     Setting,
@@ -2551,8 +2552,8 @@ class KubernetesConnector(BaseConnector):
             self.logger.info(f"Settlement duration of {settlement} has elapsed, resuming optimization.")
 
     @on_event()
-    async def check(self, filter_: Optional[Filter]) -> List[Check]:
-        return await KubernetesChecks.run(self.config, filter_)
+    async def check(self, filter_: Optional[Filter], halt_on: HaltOnFailed = HaltOnFailed.requirement) -> List[Check]:
+        return await KubernetesChecks.run(self.config, filter_, halt_on=halt_on)
 
 
 def selector_string(selectors: Mapping[str, str]) -> str:

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -33,6 +33,7 @@ from servo import (
     Description,
     Duration,
     DurationProgress,
+    Filter,
     License,
     Maturity,
     Setting,
@@ -2550,8 +2551,8 @@ class KubernetesConnector(BaseConnector):
             self.logger.info(f"Settlement duration of {settlement} has elapsed, resuming optimization.")
 
     @on_event()
-    async def check(self) -> List[Check]:
-        return await KubernetesChecks.run(self.config)
+    async def check(self, filter_: Optional[Filter]) -> List[Check]:
+        return await KubernetesChecks.run(self.config, filter_)
 
 
 def selector_string(selectors: Mapping[str, str]) -> str:

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2478,10 +2478,10 @@ class KubernetesChecks(BaseChecks):
             await KubernetesOptimizations.create(self.config)
         except Exception as e:
             return Check(
-                name="Connect to Kubernetes", success=False, comment=str(e)
+                name="Connect to Kubernetes", success=False, message=str(e)
             )
 
-        return Check(name="Connect to Kubernetes", success=True, comment="")
+        return Check(name="Connect to Kubernetes", success=True, message="")
     
     # TODO: Verify the connectivity & permissions
     # TODO: Check the Deployments exist

--- a/servo/connectors/prometheus.py
+++ b/servo/connectors/prometheus.py
@@ -16,6 +16,7 @@ from servo import (
     Description,
     Duration,
     Filter,
+    HaltOnFailed,
     License,
     Maturity,
     Measurement,
@@ -112,7 +113,7 @@ class PrometheusConnector(BaseConnector):
     config: PrometheusConfiguration
 
     @on_event()
-    async def check(self, filter_: Optional[Filter]) -> List[Check]:
+    async def check(self, filter_: Optional[Filter], halt_on: HaltOnFailed = HaltOnFailed.requirement) -> List[Check]:
         start, end = datetime.now() - timedelta(minutes=10), datetime.now()        
         async def check_query(metric: PrometheusMetric) -> str:
             result = await self._query_prom(metric, start, end)
@@ -120,7 +121,7 @@ class PrometheusConnector(BaseConnector):
 
         # wrap all queries into checks and verify that they work
         PrometheusChecks = create_checks_from_iterable(check_query, self.config.metrics)
-        return await PrometheusChecks.run(self.config, filter_)
+        return await PrometheusChecks.run(self.config, filter_, halt_on=halt_on)
 
     @on_event()
     def describe(self) -> Description:

--- a/servo/connectors/prometheus.py
+++ b/servo/connectors/prometheus.py
@@ -113,7 +113,10 @@ class PrometheusConnector(BaseConnector):
     config: PrometheusConfiguration
 
     @on_event()
-    async def check(self, filter_: Optional[Filter], halt_on: HaltOnFailed = HaltOnFailed.requirement) -> List[Check]:
+    async def check(self, 
+        filter_: Optional[Filter] = None, 
+        halt_on: HaltOnFailed = HaltOnFailed.requirement
+    ) -> List[Check]:
         start, end = datetime.now() - timedelta(minutes=10), datetime.now()        
         async def check_query(metric: PrometheusMetric) -> str:
             result = await self._query_prom(metric, start, end)

--- a/servo/connectors/vegeta.py
+++ b/servo/connectors/vegeta.py
@@ -322,14 +322,14 @@ class VegetaConnector(BaseConnector):
         checks.append(Check(
             name="Vegeta execution",
             success=(exit_code == 0),
-            comment=f"Vegeta exit code: {exit_code}",
+            message=f"Vegeta exit code: {exit_code}",
         ))
 
         # Look at the error rate
         checks.append(Check(
             name="Report aggregation",
             success=(len(self.vegeta_reports) > 0),
-            comment=f"Collected {len(self.vegeta_reports)} reports",
+            message=f"Collected {len(self.vegeta_reports)} reports",
         ))
         if self.vegeta_reports:
             vegeta_report = self.vegeta_reports[-1]
@@ -337,7 +337,7 @@ class VegetaConnector(BaseConnector):
             checks.append(Check(
                 name="Error rate < 5.0%",
                 success=success,
-                comment=f"Vegeta reported an error rate of {vegeta_report.error_rate:.2f}%",
+                message=f"Vegeta reported an error rate of {vegeta_report.error_rate:.2f}%",
             ))
 
         return checks

--- a/servo/connectors/vegeta.py
+++ b/servo/connectors/vegeta.py
@@ -503,7 +503,7 @@ def _summarize_report(report: VegetaReport, config: VegetaConfiguration) -> str:
     latency_99th = format_metric(report.latencies.p99, Unit.MILLISECONDS)
     return f'Vegeta attacking "{config.target}" @ {config.rate}: ~{throughput} ({error_rate} errors) [latencies: 50th={latency_50th}, 90th={latency_90th}, 95th={latency_95th}, 99th={latency_99th}]'
 
-def _number_of_lines_in_file(filename: Path):
+def _number_of_lines_in_file(filename: Path) -> int:
     count = 0
     with open(filename, "r") as f:
         for _ in f:

--- a/servo/connectors/vegeta.py
+++ b/servo/connectors/vegeta.py
@@ -21,6 +21,7 @@ from servo import (
     Description,
     Duration,
     DurationProgress,
+    Filter,
     License,
     Maturity,
     Measurement,
@@ -333,7 +334,7 @@ class VegetaConnector(BaseConnector):
         return METRICS
 
     @on_event()
-    async def check(self, **kwargs) -> List[Check]:
+    async def check(self, filter_: Optional[Filter] = None) -> List[Check]:
         # Take the current config and run a 5 second check against it
         self.warmup_until = datetime.now()
         check_config = self.config.copy()
@@ -341,7 +342,7 @@ class VegetaConnector(BaseConnector):
         check_config.reporting_interval = "1s"
 
         checks = VegetaChecks(config=check_config, runner=self._run_vegeta)
-        return await checks.run(**kwargs)
+        return await checks.run_(filter_)
 
     @on_event()
     async def measure(

--- a/servo/connectors/vegeta.py
+++ b/servo/connectors/vegeta.py
@@ -22,6 +22,7 @@ from servo import (
     Duration,
     DurationProgress,
     Filter,
+    HaltOnFailed,
     License,
     Maturity,
     Measurement,
@@ -334,7 +335,7 @@ class VegetaConnector(BaseConnector):
         return METRICS
 
     @on_event()
-    async def check(self, filter_: Optional[Filter] = None) -> List[Check]:
+    async def check(self, filter_: Optional[Filter] = None, halt_on: HaltOnFailed = HaltOnFailed.requirement) -> List[Check]:
         # Take the current config and run a 5 second check against it
         self.warmup_until = datetime.now()
         check_config = self.config.copy()
@@ -342,7 +343,7 @@ class VegetaConnector(BaseConnector):
         check_config.reporting_interval = "1s"
 
         checks = VegetaChecks(config=check_config, runner=self._run_vegeta)
-        return await checks.run_(filter_)
+        return await checks.run_(filter_, halt_on=halt_on)
 
     @on_event()
     async def measure(

--- a/servo/connectors/vegeta.py
+++ b/servo/connectors/vegeta.py
@@ -295,13 +295,13 @@ class VegetaChecks(BaseChecks):
     runner: VegetaRunner
     reports: Optional[List[VegetaReport]] = None
 
-    @check("Vegeta execution")
+    @check("Vegeta execution", required=True)
     async def check_execution(self) -> Tuple[bool, str]:
         exit_code, reports = await self.runner(config=self.config)
         self.reports = reports
         return (exit_code == 0, f"Vegeta exit code: {exit_code}")
     
-    @check("Report aggregation", required=True)
+    @check("Report aggregation")
     def check_report_aggregation(self) -> Tuple[bool, str]:
         return (len(self.reports) > 0, f"Collected {len(self.reports)} reports")
     
@@ -333,7 +333,7 @@ class VegetaConnector(BaseConnector):
         return METRICS
 
     @on_event()
-    async def check(self) -> List[Check]:
+    async def check(self, **kwargs) -> List[Check]:
         # Take the current config and run a 5 second check against it
         self.warmup_until = datetime.now()
         check_config = self.config.copy()
@@ -341,7 +341,7 @@ class VegetaConnector(BaseConnector):
         check_config.reporting_interval = "1s"
 
         checks = VegetaChecks(config=check_config, runner=self._run_vegeta)
-        return await checks.run()
+        return await checks.run(**kwargs)
 
     @on_event()
     async def measure(

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import abc
 import asyncio
+import importlib
 import inspect
 from contextvars import ContextVar
 from enum import Enum
@@ -17,9 +18,7 @@ from servo.connector import (
     BaseConnector,
     License,
     Maturity,
-    _connector_subclasses,
-    _connector_class_from_string,
-    _validate_class
+    _connector_subclasses
 )
 from servo.checks import Check
 from servo.events import Preposition, event, on_event

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -20,7 +20,7 @@ from servo.connector import (
     Maturity,
     _connector_subclasses
 )
-from servo.checks import Check, Filter
+from servo.checks import Check, Filter, HaltOnFailed
 from servo.events import Preposition, event, on_event
 from servo.types import Adjustment, Component, Control, Description, Duration, Measurement, Metric
 
@@ -84,7 +84,7 @@ class _EventDefinitions:
         yield
 
     @event(Events.CHECK)
-    async def check(self, filter_: Optional[Filter]) -> List[Check]:
+    async def check(self, filter_: Optional[Filter], halt_on: HaltOnFailed = HaltOnFailed.requirement) -> List[Check]:
         ...
 
     @event(Events.DESCRIBE)

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -266,7 +266,7 @@ class Servo(BaseConnector):
     # Event handlers
 
     @on_event()
-    async def check(self, filter_: Optional[Filter]) -> List[Check]:
+    async def check(self, filter_: Optional[Filter], halt_on: HaltOnFailed = HaltOnFailed.requirement) -> List[Check]:
         async with self.api_client() as client:
             event_request = api.Request(event=api.Event.HELLO)
             response = await client.post("servo", data=event_request.json())

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -21,8 +21,9 @@ from servo.connector import (
     _connector_class_from_string,
     _validate_class
 )
+from servo.checks import Check
 from servo.events import Preposition, event, on_event
-from servo.types import Adjustment, Check, Component, Control, Description, Duration, Measurement, Metric
+from servo.types import Adjustment, Component, Control, Description, Duration, Measurement, Metric
 
 
 _servo_context_var = ContextVar("servo.Servo.current", default=None)
@@ -274,7 +275,7 @@ class Servo(BaseConnector):
             return [Check(
                 name="Opsani API connectivity",
                 success=success,
-                comment=f"Response status code: {response.status_code}",
+                message=f"Response status code: {response.status_code}",
             )]
 
 

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Dict, Iterable, List, Optional, Type, Union, Sequence
 
 import httpx
-from pydantic import AnyHttpUrl, Extra, Field, validator
+from pydantic import Extra, Field, validator
 
 import servo
 from servo import api, connector
@@ -20,7 +20,7 @@ from servo.connector import (
     Maturity,
     _connector_subclasses
 )
-from servo.checks import Check
+from servo.checks import Check, Filter
 from servo.events import Preposition, event, on_event
 from servo.types import Adjustment, Component, Control, Description, Duration, Measurement, Metric
 
@@ -84,7 +84,7 @@ class _EventDefinitions:
         yield
 
     @event(Events.CHECK)
-    async def check(self) -> List[Check]:
+    async def check(self, filter_: Optional[Filter]) -> List[Check]:
         ...
 
     @event(Events.DESCRIBE)
@@ -266,7 +266,7 @@ class Servo(BaseConnector):
     # Event handlers
 
     @on_event()
-    async def check(self) -> List[Check]:
+    async def check(self, filter_: Optional[Filter]) -> List[Check]:
         async with self.api_client() as client:
             event_request = api.Request(event=api.Event.HELLO)
             response = await client.post("servo", data=event_request.json())
@@ -391,3 +391,49 @@ def _routes_for_connectors_descriptor(connectors) -> Dict[str, BaseConnector]:
         raise ValueError(
             f"Unexpected type `{type(connectors).__qualname__}`` encountered (connectors: {connectors})"
         )
+
+
+def _connector_class_from_string(connector: str) -> Optional[Type[BaseConnector]]:
+    if not isinstance(connector, str):
+        return None
+
+    # Check for an existing class in the namespace
+    # FIXME: This symbol lookup doesn't seem solid
+    connector_class = globals().get(connector, None)
+    try:
+        connector_class = (
+            eval(connector) if connector_class is None else connector_class
+        )
+    except Exception:
+        pass
+    
+    if _validate_class(connector_class):
+        return connector_class
+
+    # Check if the string is an identifier for a connector
+    for connector_class in _connector_subclasses:
+        if connector == connector_class.__default_name__ or connector in [
+            connector_class.__name__,
+            connector_class.__qualname__,
+        ]:
+            return connector_class
+
+    # Try to load it as a module path
+    if "." in connector:
+        module_path, class_name = connector.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        if hasattr(module, class_name):
+            connector_class = getattr(module, class_name)
+            if _validate_class(connector_class):
+                return connector_class
+
+    return None
+
+def _validate_class(connector: type) -> bool:
+    if connector is None or not isinstance(connector, type):
+        return False
+
+    if not issubclass(connector, BaseConnector):
+        raise TypeError(f"{connector.__name__} is not a Connector subclass")
+
+    return True

--- a/servo/types.py
+++ b/servo/types.py
@@ -414,20 +414,6 @@ class Measurement(BaseModel):
         return dict(metrics=readings, annotations=self.annotations)
 
 
-class Check(BaseModel):
-    name: str
-    description: Optional[str]
-    required: bool = True
-    success: bool
-    comment: Optional[str]
-    created_at: datetime = None
-
-    @validator("created_at", pre=True, always=True)
-    @classmethod
-    def set_created_at_now(cls, v):
-        return v or datetime.now()
-
-
 class Adjustment(BaseModel):
     component_name: str
     setting_name: str

--- a/servo/utilities/inspect.py
+++ b/servo/utilities/inspect.py
@@ -1,0 +1,86 @@
+import inspect
+import warnings
+from collections import ChainMap
+from typing import Any, Dict, Callable, List, Optional, Type, Tuple, cast
+
+def get_instance_methods(obj, *, stop_at_parent: Optional[Type[Any]] = None) -> Dict[str, Callable]:
+    """
+    Returns a mapping of method names to method callables in definition order, optionally traversing
+    the inheritance hierarchy in method dispatch order.
+
+    Note that the semantics of the values in the dictionary returned are dependent on the input object.
+    When `obj` is an object instance, the values are bound method objects (as returned by `get_methods`).
+    When `obj` is a class, the values are unbound function objects. Depending on what you are trying to
+    do, this may have interesting ramifications (for example, the method signature of the callable will
+    include `self` in the parameters list). This behavior is a side-effect of the lookup implementation
+    which is utilized because it retains method definition order. To obtain a bound method object reference, 
+    go through `get_methods` or call `getattr` on an instance.
+
+    Args:
+        obj: The object or class to retrieve the instance methods for.
+        stop_at_parent: The parent class to halt the inheritance traversal at. When None, only
+            instance methods of `obj` are returned.
+    
+    Returns:
+        A dictionary of methods in definition order.
+    """
+    cls = obj if inspect.isclass(obj) else obj.__class__
+    methods = ChainMap()
+    stopped = False
+
+    for c in inspect.getmro(cls):
+        methods.maps.append(
+            dict(filter(lambda item: inspect.isfunction(item[1]), c.__dict__.items()))
+        )
+        if not stop_at_parent or c == stop_at_parent:
+            stopped = True
+            break
+    
+    if not stopped:
+        raise TypeError(f'invalid parent type "{stop_at_parent}": not found in inheritance hierarchy')
+    
+    if isinstance(obj, cls):
+        # Update the values to bound method references
+        return dict(map(lambda name: (name, getattr(obj, name)), methods.keys()))
+    else:
+        return cast(dict, methods)
+
+
+def get_methods(cls: Type[Any]) -> List[Tuple[str, Any]]:
+    """
+    Return a list of tuple of methods for the given class in alphabetical order.
+
+    Args:
+        cls: The class to retrieve the methods of.
+    
+    Returns:
+        A list of tuples containing method names and bound method objects.
+    """
+    # retrieving the members can emit deprecation warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return inspect.getmembers(cls, inspect.ismethod)
+
+
+def get_defining_class(method: Callable) -> Optional[Type[Any]]:
+    """
+    Return the class that defined the given method.
+
+    Args:
+        method: The method to return the defining class of.
+    
+    Return:
+        The class that defined the method or None if not determined.
+    """
+    for cls in inspect.getmro(method.__self__.__class__):
+        if method.__name__ in cls.__dict__:
+            return cls
+
+    meth = getattr(method, '__func__', method)  # fallback to __qualname__ parsing
+    cls = getattr(inspect.getmodule(method),
+                method.__qualname__.split('.<locals>', 1)[0].rsplit('.', 1)[0],
+                None)
+    if isinstance(cls, type):
+        return cls
+
+    return None

--- a/tests/checks_test.py
+++ b/tests/checks_test.py
@@ -1,0 +1,360 @@
+import pytest
+import re
+from datetime import datetime
+from inspect import Signature
+from servo.configuration import BaseConfiguration
+from servo.checks import Check, BaseChecks, check
+from servo.configuration import BaseConfiguration
+from servo.checks import check as check_decorator, CheckHandlerResult
+from servo.utilities.inspect import get_instance_methods
+from typing import List, Tuple, Union, Optional
+
+
+pytestmark = pytest.mark.freeze_time('2020-08-24')
+
+
+def test_created_at_set_automatically() -> None:
+    check = Check(name="Test", success=True)
+    assert check.created_at == datetime(2020, 8, 24, 0, 0)
+
+def test_serialize_with_exception() -> None:
+    exception = RuntimeError("Testing")
+    check = Check(name="Test", success=False, exception=exception)
+    assert check.json() == (
+        '{"name": "Test", "id": "1bab7e8d", "description": null, "required": false, "tags": null, "success": false, "message": null, "exception": "RuntimeError(\'Testing\')", "created_at": "2020-08-24T00:00:00", "run_at": null, "runtime": null}'
+    )
+
+def test_inline_check() -> None:
+    check = Check.run("Test Inline Runner", handler=lambda: True)
+    assert check
+    assert check.name == "Test Inline Runner"
+    assert check.success
+    assert check.created_at == datetime(2020, 8, 24, 0, 0)
+
+def test_inline_check_failure() -> None:
+    def failing_check() -> None:
+        raise RuntimeError("Testing Failure")
+
+    check = Check.run("Test Inline Failure", handler=failing_check)
+    assert check
+    assert check.name == "Test Inline Failure"
+    assert not check.success
+    assert check.created_at == datetime(2020, 8, 24, 0, 0)
+
+##
+## Checks class specific
+
+async def test_raises_on_invalid_method_name() -> None:
+    class MeasureChecks(BaseChecks):
+        def invalid_check(self) -> Check:
+            return Check(name="Test", success=True)
+        
+    with pytest.raises(ValueError) as e:
+        config = BaseConfiguration()
+        await MeasureChecks.check(config)
+    
+    assert e
+    assert str(e.value) == "method names of Checks subtypes must start with \"_\" or \"check_\""
+
+async def test_allows_underscored_method_names() -> None:
+    class MeasureChecks(BaseChecks):
+        def _allowed_helper(self) -> Check:
+            return Check(name="Test", success=True)
+    
+    config = BaseConfiguration()
+    assert await MeasureChecks.check(config)
+
+async def test_raises_on_invalid_signature() -> None:
+    class MeasureChecks(BaseChecks):
+        def check_invalid(self) -> int:
+            return 123
+    
+    with pytest.raises(TypeError) as e:
+        config = BaseConfiguration()
+        await MeasureChecks.check(config)
+
+    assert e
+    assert str(e.value) == 'invalid signature for method "check_invalid": expected <Signature () -> servo.checks.Check>, but found <Signature () -> int>'
+
+async def test_valid_checks() -> None:
+    class MeasureChecks(BaseChecks):
+        def check_something(self) -> Check:
+            return Check(name="Test", success=True)
+    
+    config = BaseConfiguration()
+    checks = await MeasureChecks.check(config)
+    assert checks == [Check(name='Test', success=True, created_at=datetime(2020, 8, 24, 0, 0))]
+
+async def test_run_as_instance() -> None:
+    class MeasureChecks(BaseChecks):
+        def check_something(self) -> Check:
+            return Check(name="Test", success=True)
+    
+    config = BaseConfiguration()
+    checker = MeasureChecks(config)
+    checks = await checker.run()
+    assert checks == [Check(name='Test', success=True, created_at=datetime(2020, 8, 24, 0, 0))]
+
+async def test_check_ordering() -> None:
+    class MeasureChecks(BaseChecks):
+        def check_one(self) -> Check:
+            return Check(name="1", success=True)
+        
+        def check_two(self) -> Check:
+            return Check(name="2", success=False)
+        
+        def check_three(self) -> Check:
+            return Check(name="3", success=True)
+    
+    config = BaseConfiguration()
+    checks = await MeasureChecks.check(config)
+    values = list(map(lambda c: (c.name, c.success), checks))
+    assert values == [("1", True), ("2", False), ("3", True)]
+
+async def test_check_aborts_on_failed_requirement() -> None:
+    class MeasureChecks(BaseChecks):
+        def check_one(self) -> Check:
+            return Check(name="1", success=True)
+        
+        def check_two(self) -> Check:
+            return Check(name="2", success=False, required=True)
+        
+        def check_three(self) -> Check:
+            return Check(name="3", success=True)
+    
+    config = BaseConfiguration()
+    checks = await MeasureChecks.check(config)
+    values = list(map(lambda c: (c.name, c.success), checks))
+    assert values == [("1", True), ("2", False)]
+
+class NamedChecks(BaseChecks):
+    @check_decorator("Check connectivity")
+    def check_connectivity(self) -> CheckHandlerResult:
+        return True
+
+    def check_permissions(self) -> Check:
+        return Check(name="Verify permissions", success=False)
+
+    def check_resources(self) -> Check:
+        return Check(name="Ensure adequate resources", success=True)
+
+@pytest.mark.parametrize(
+    "return_value, success, message",
+    [
+        ("this is the message", True, "this is the message"),
+        (True, True, None),
+        ((False, "didn't work"), False, "didn't work"),
+        (None, True, None),
+    ]
+)
+def test_valid_check_decorator_return_values(return_value, success, message) -> None:    
+    @check_decorator("Test decorator")
+    def check_test() -> CheckHandlerResult:
+        return return_value
+    
+    check = check_test()
+    assert check
+    assert isinstance(check, Check)
+    assert check.success == success
+    assert check.message == message
+    assert check.exception is None
+
+@pytest.mark.parametrize(
+    "return_value, exception_type, message",
+    [
+        (123, ValueError, (
+            "caught exception: ValueError('check method returned unexpected value of type \"int\"')"
+        )),
+        ((False, 187), ValueError, (
+            "caught exception: ValidationError(model='Check', errors=[{'loc': ('message',), 'msg': 'str type expected'"
+            ", 'type': 'type_error.str'}])"
+        )),
+        ((666, "fail"), ValueError, (
+            "caught exception: ValidationError(model='Check', errors=[{'loc': ('success',), 'msg': 'value could not be"
+            " parsed to a boolean', 'type': 'type_error.bool'}])"
+        )),
+    ]
+)
+def test_invalid_check_decorator_return_values(return_value, exception_type, message) -> None:
+    @check_decorator("Test decorator")
+    def check_test() -> CheckHandlerResult:
+        return return_value
+    
+    check = check_test()
+    assert check
+    assert isinstance(check, Check)
+    assert check.success == False    
+    assert check.message == message
+    assert check.exception is not None
+    assert isinstance(check.exception, exception_type)
+
+class ValidHandlerSignatures:
+    def check_none(self) -> None:
+        ...
+    
+    def check_str(self) -> str:
+        ...
+    
+    def check_bool(self) -> bool:
+        ...
+    
+    def check_tuple(self) -> Tuple[bool, str]:
+        ...
+    
+    def check_union(self) -> Union[str, bool]:
+        ...
+    
+    def check_optional(self) -> Optional[str]:
+        ...
+    
+    def check_union_of_tuple(self) -> Union[str, Tuple[bool, str]]:
+        ...
+    
+    def check_optional_tuple(self) -> Optional[Tuple[bool, str]]:
+        ...
+
+@pytest.mark.parametrize(
+    "method",
+    get_instance_methods(ValidHandlerSignatures()).values(),
+    ids=get_instance_methods(ValidHandlerSignatures()).keys()
+)
+def test_valid_signatures(method) -> None:
+    check_decorator(method.__name__)(method)
+
+class InvalidHandlerSignatures:
+    def check_int(self) -> int:
+        ...
+    
+    def check_list(self) -> List[Check]:
+        ...
+    
+    def check_invalid_tuple(self) -> Tuple[int, str]:
+        ...
+    
+    def check_invalid_optional(self) -> Optional[float]:
+        ...
+    
+    def check_invalid_union(self) -> Union[bool, str, float]:
+        ...
+    
+    def check_invalid_union_with_tuple(self) -> Union[bool, Tuple[str, float]]:
+        ...
+
+@pytest.mark.parametrize(
+    "method",
+    get_instance_methods(InvalidHandlerSignatures()).values()
+)
+def test_invalid_signatures(method) -> None:
+    with pytest.raises(TypeError) as e:
+        check_decorator(method.__name__)(method)
+
+    sig = Signature.from_callable(method)
+    message = f'invalid check handler "{method.__name__}": incompatible return type annotation in signature {repr(sig)}, expected to match <Signature () -> Union[bool, str, Tuple[bool, str], NoneType]>'
+    assert str(e.value) == message
+
+def test_decorating_invalid_signatures() -> None:
+    with pytest.raises(TypeError) as e:
+        @check_decorator("Test decorator")
+        def check_test() -> int:
+            ...
+    
+    assert e
+    assert str(e.value) == (
+        'invalid check handler "check_test": incompatible return type annotation in signature <Signature () -> int>, e'
+        'xpected to match <Signature () -> Union[bool, str, Tuple[bool, str], NoneType]>'
+    )
+
+@pytest.mark.freeze_time('2020-08-25', auto_tick_seconds=15)
+async def test_check_timer() -> None:
+    @check_decorator("Check timer")
+    def check_test() -> CheckHandlerResult:
+        return return_value
+    
+    check = check_test()
+    assert check
+    assert isinstance(check, Check)
+    assert check.run_at == datetime(2020, 8, 25, 0, 0, 15)
+    assert check.runtime == "15s"
+
+
+async def test_run_check_by_name() -> None:
+    nc = NamedChecks(BaseConfiguration())
+    checks = await nc.run(name="Check connectivity")
+    check = checks[0]
+    assert check
+    assert check.name == "Check connectivity"
+    assert check.success
+
+def test_generate_check_id() -> None:
+    check = Check(name="Ensure adequate resources", success=True)
+    assert check.id == "c272d5e0"
+
+def test_decorator_sets_id_to_method_name() -> None:
+    checks = NamedChecks(BaseConfiguration())
+    assert checks.check_connectivity.__check__.id == "check_connectivity"
+
+async def test_run_check_by_id() -> None:
+    nc = NamedChecks(BaseConfiguration())
+    checks = await nc.run(id="check_connectivity")
+    assert len(checks) == 1
+    check = checks[0]
+    assert check
+    assert check.name == "Check connectivity"
+    assert check.success
+
+class FilterableChecks(BaseChecks):
+    @check("name-only")
+    def check_one(self) -> None:
+        ...
+    
+    @check("name-and-id", id="explicit-id")
+    def check_two(self) -> None:
+        ...
+    
+    @check("name-and-tags", tags=["one", "two"])
+    def check_three(self) -> None:
+        ...
+    
+    @check("name-and-identicial-tags", tags=["one", "two"])
+    def check_four(self) -> None:
+        ...
+    
+    @check("name-and-exclusive-tags", tags=["three", "four"])
+    def check_five(self) -> None:
+        ...
+    
+    @check("name-and-intersecting-tags", tags=["one", "four"])
+    def check_six(self) -> None:
+        ...
+
+@pytest.mark.parametrize(
+    "name, id, tags, expected_ids",
+    [
+        # name cases
+        ("name-only", None, None, ["check_one"]),
+        ("invalid", None, None, []),
+        (("name-only", "name-and-id"), None, None, ["check_one", "explicit-id"]),
+        (["name-only", "name-and-id"], None, None, ["check_one", "explicit-id"]),
+        (re.compile('.*tags'), None, None, ['check_three', 'check_four', 'check_five', 'check_six']),
+        
+        # id cases
+        (None, 'explicit-id', None, ['explicit-id']),
+        (None, ('explicit-id', 'check_three'), None, ['explicit-id', 'check_three']),
+        (None, re.compile('[i]+'), None, ['explicit-id', 'check_five', 'check_six']),
+
+        # tag cases
+        (None, None, ["one"], ['check_three','check_four','check_six']),
+        (None, None, set(), []),
+        (None, None, ("one", "four"), ["check_three", "check_four", "check_five", "check_six"]),
+        (None, None, {"invalid"}, []),
+
+        # compound cases
+        (None, re.compile('[i]+'), {"four"}, ['check_five', 'check_six']),
+        (re.compile('exclusive'), re.compile('[i]+'), None, ['check_five']),
+    ]
+)
+async def test_filtering(name, id, tags, expected_ids) -> None:
+    checks = await FilterableChecks.check(BaseConfiguration(), name=name, id=id, tags=tags)    
+    ids = list(map(lambda c: c.id, checks))
+    assert len(ids) == len(expected_ids)
+    assert ids == expected_ids

--- a/tests/checks_test.py
+++ b/tests/checks_test.py
@@ -485,4 +485,6 @@ async def test_generate_checks() -> None:
     checker = ItemChecks(BaseConfiguration())
     results = await checker.run()
     assert len(results) == 3
+    messages = list(map(lambda c: c.message, results))
+    assert messages == ["so_check_it_one", "so_check_it_two", "so_check_it_three"]
 

--- a/tests/checks_test.py
+++ b/tests/checks_test.py
@@ -476,3 +476,13 @@ async def test_mixed_checks(name, expected_results) -> None:
     checks = await MixedChecks.check(BaseConfiguration(), name=name)
     actual_results = list(map(lambda c: c.name, checks))
     assert actual_results == expected_results
+
+from servo.checks import create_checks_from_iterable
+async def test_generate_checks() -> None:
+    handler = lambda c: f"so_check_it_{c}"
+    items = ["one", "two", "three"]
+    ItemChecks = create_checks_from_iterable(handler, items)
+    checker = ItemChecks(BaseConfiguration())
+    results = await checker.run()
+    assert len(results) == 3
+

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -129,7 +129,7 @@ def test_check_verbose(
     result = cli_runner.invoke(servo_cli, "check -v", catch_exceptions=False)
     assert request.called
     assert result.exit_code == 0    
-    assert re.search("CONNECTOR\\s+CHECK\\s+STATUS\\s+MESSAGE", result.stdout)
+    assert re.search("CONNECTOR\\s+CHECK\\s+ID\\s+TAGS\\s+STATUS\\s+MESSAGE", result.stdout)
 
 
 def test_show_help_requires_optimizer(cli_runner: CliRunner, servo_cli: Typer) -> None:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -129,7 +129,7 @@ def test_check_verbose(
     result = cli_runner.invoke(servo_cli, "check -v", catch_exceptions=False)
     assert request.called
     assert result.exit_code == 0    
-    assert re.search("CONNECTOR\\s+CHECK\\s+STATUS\\s+COMMENT", result.stdout)
+    assert re.search("CONNECTOR\\s+CHECK\\s+STATUS\\s+MESSAGE", result.stdout)
 
 
 def test_show_help_requires_optimizer(cli_runner: CliRunner, servo_cli: Typer) -> None:

--- a/tests/connector_test.py
+++ b/tests/connector_test.py
@@ -495,18 +495,18 @@ class TestVegetaConnector:
     @pytest.fixture(autouse=True)
     def mock_run_vegeta(self, mocker) -> None:
         mocker.patch.object(
-            VegetaConnector, "_run_vegeta", return_value=(1, "vegeta attack")
+            VegetaConnector, "_run_vegeta", return_value=(1, [])
         )
 
     async def test_vegeta_check(self, vegeta_connector: VegetaConnector, mocker) -> None:
         mocker.patch.object(
-            VegetaConnector, "_run_vegeta", return_value=(0, "vegeta attack")
+            VegetaConnector, "_run_vegeta", return_value=(0, [])
         )
         await vegeta_connector.check()
 
     def test_vegeta_metrics(self, vegeta_connector: VegetaConnector, mocker) -> None:
         mocker.patch.object(
-            VegetaConnector, "_run_vegeta", return_value=(0, "vegeta attack")
+            VegetaConnector, "_run_vegeta", return_value=(0, [])
         )
         vegeta_connector.metrics()
 

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -620,7 +620,7 @@ async def test_apply_restart_strategy():
 # Handle: CreateContainerError 
 
 async def test_checks(config: KubernetesConfiguration):
-    await KubernetesChecks.run(config)
+    await KubernetesChecks.check(config)
 
 def test_millicpu():
     class Model(pydantic.BaseModel):

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -620,7 +620,7 @@ async def test_apply_restart_strategy():
 # Handle: CreateContainerError 
 
 async def test_checks(config: KubernetesConfiguration):
-    await KubernetesChecks.check(config)
+    await KubernetesChecks.run(config)
 
 def test_millicpu():
     class Model(pydantic.BaseModel):

--- a/tests/utilities/inspect_test.py
+++ b/tests/utilities/inspect_test.py
@@ -1,0 +1,47 @@
+import pytest
+import inspect
+from functools import reduce
+from servo.utilities.inspect import get_instance_methods, get_methods, get_defining_class
+
+class OneClass:
+    def one(self) -> None:
+        ...
+    
+    def two(self) -> None:
+        ...
+    
+    def three(self) -> None:
+        ...
+class TwoClass(OneClass):
+    def four(self) -> None:
+        ...
+    
+    def five(self) -> None:
+        ...
+class ThreeClass(TwoClass):
+    def six(self) -> None:
+        ...
+
+@pytest.mark.parametrize(
+    "cls, stop_at_parent, method_names",
+    [
+        (OneClass, None, ['one', 'two', 'three']),
+        (TwoClass, None, ['four', 'five']),
+        (TwoClass, OneClass, ['one', 'two', 'three', 'four', 'five']),
+        (ThreeClass, OneClass, ['one', 'two', 'three', 'four', 'five', 'six']),
+        (ThreeClass, TwoClass, ['four', 'five', 'six']),
+    ]
+)
+def test_get_instance_methods(cls, stop_at_parent, method_names) -> None:
+    methods = get_instance_methods(cls, stop_at_parent=stop_at_parent)
+    assert list(methods.keys()) == method_names
+
+def test_get_instance_methods_invalid_parent() -> None:
+    with pytest.raises(TypeError) as e:
+        get_instance_methods(OneClass, stop_at_parent=int)
+    assert str(e.value) == 'invalid parent type "<class \'int\'>": not found in inheritance hierarchy'
+
+def test_get_instance_methods_returns_bound_methods_if_possible() -> None:
+    methods = get_instance_methods(ThreeClass(), stop_at_parent=OneClass)
+    assert list(methods.keys()) == ['one', 'two', 'three', 'four', 'five', 'six']
+    assert reduce(lambda bound, m: bound & inspect.ismethod(m), methods.values(), True)


### PR DESCRIPTION
This PR contains a revised and expanded implementation of the `servo check` functionality.

## Background context (skip down if you can't be bothered)

For the uninitiated, a `Check` object represents a runtime for that a particular dependency is available or that configuration is correct. Examples include "Can I talk to Redis?", "Does my service account in Kubernetes have sufficient permissions?", and "Are my Prometheus queries well-formed and returning results?".

As I have been building out Opsani Dev and doing a ton of setup and tear-down work, I have become increasingly convinced that checks represent a key driver of deployment efficiency and user experience. The most difficult aspects of getting a deployment live are **gathering information** (a social problem) and **verifying requirements and configuration** (a technical problem). Checks provide a workflow and feedback loop that enables us to move rapidly between data gathering and verification in a sustainable and repeatable way.

The original check implementation provided a dead simple mechanism for servo connectors to run a self-survey and return a pass/fail value with an accompanying descriptive message. This quickly proved to be insufficient because trying to aggregate all the dimensions of connector status into a single boolean and string description became incomprehensible.

The next implementation expanded from a single check value into a list of checks, enabling checks to become atomic and better model the internal realities of connectors that may be partially working. This model carried us for quite a while.

As the collection of connectors continued to grow and configuration became more complex, cracks started to form in the list of checks approach. For one thing, the check methods started to grow very large by virtue of the amount of boilerplate code necessary to run checks -- it typically requires rescuing and introspecting exceptions, building a collection of objects literals, and then actually implementing the logic. 

But then, the real problems started to show. Because checks were written linearly within the `check` event handler, failures that occur deep in the list of checks would not execute until everything else before it had completed. For some situations, this is just some annoying latency that slows down the feedback loop. But in others where you have long-running check implementations, it is a deal-breaker. For example, when implementing checks for Kubernetes there are a series of things that you want to run, starting from seeing if you can connect to the API server and then scaling up to "Can I deploy a canary?", "Can I scale this service to the maximum replica count?", "Can a Pod I create pull an image?", "Will the scheduler schedule a Pod with the lowest and highest guardrails?", etc. All of these operations are potentially long-running. This creates developer and operator tension (in this case me being mad at myself) because on the one hand you want to focus on completeness and correctness so you want to be exhaustive in the things you check, while on the other you want a high throughput workflow to focus only on the problems and get shit done.

After pondering these challenges for a while and sketching out a number of designs, I finally landed on something that I think is really solid.

## Checks 2.0

Features:

* Create check from method
* Create multiple checks in a class
* Create checks from an iterable (e.g. a list)
* Required checks
* Check metadata
* Filtering checks
* Halting runs
* Instrumentation
* Enhanced CLI
* Checkable Protocol
* Safe and productive by default

### Creating a Check

Checks can now be created with a decorator:

```python
@check("Something...")
def check_something() -> None:
  ...
```

The decorator transforms the function into a method that returns a `Check` object. When called it, it invokes the original method implementation and determines success/failure based on the return type:

```python
@check("Success")
def check_success() -> bool:
  return True # the check succeeded

@check("Failure")
def check_failure() -> bool:
  return False # failed

@check("Fail by exception")
def check_exception() -> None:
  raise RuntimeError("Something went wrong")
```

Exceptions are guarded for you. Write the shortest code possible that can check the condition.

You can also return a message that will be displayed in the CLI (more on this later):

```python
@check("Message")
def check_message() -> str:
  return "Success message"
```

or return a bool and message to do both at once:

```python
@check("Tuple outcome")
def check_tuple() -> Tuple[bool, str]:
  return (True, "Returning a tuple value works fine")
```

A check that returns `None` and doesn't raise is a success:

```python
@check("None")
def check_none() -> None:
  print("Whatever I do here is a success unless I raise an error.")
```

### Check metadata

Checks can be enriched with metadata:

```python
@check("Metadata",
    description="Include a longer detailed description here...",
    id="metadata",
    tags=("fast", "low_priority"),
)
def check_metadata() -> None:
  ...
```

Metadata comes into play a bit later. But for now, keep in mind that the `id` is a short unique identifier that will be auto-assigned if unspecified and `tags` is a set of lightweight descriptors about check behavior and context.

### Creating Checks

Checking several conditions in one connector can be verbose even with the decorator:

```python
class SomeConnector(BaseConnector):
    @event()
    async def check(self) -> List[Check]:
        @check("one")
        def check_one() -> None:
            ...
        
        @check("two")
        def check_two() -> None:
            ...
        
        @check("three")
        def check_three() -> None:
            ...
        
        return [check_one(), check_two(), check_three()]
```

but more importantly, there is no way to work with the collection. It's an all or nothing operation where all the checks are run and returned every time you call `servo check`.

We can do better on both fronts:

```python
class SomeChecks(BaseChecks):
    @check("one")
    async def check_one(self) -> None:
        ...
    
    @check("two")
    async def check_two(self) -> None:
        ...
    
    @check("three")
    async def check_three(self) -> None:
        ...

class SomeConnector(BaseConnector):
    @event()
    async def check(self) -> List[Check]:
        return await SomeChecks.run(self.config)
```

The checks are now encapsulated into a standalone class that can be tested in isolation. The check event handler is now nice and tidy.

The `BaseChecks` class has some interesting capabilities. It enforces a policy that all instance methods are prefixed with `check_` and return a `Check` object or are designated as helper methods by starting with an underscore:

```python
class ValidExampleChecks(BaseChecks):
    @check("valid")
    async def check_valid(self) -> None:
        ...
    
    def _reverse_string(self, input: str) -> str:
        return input.reverse()

class InvalidExampleChecks(BaseChecks):
    # Forgot to decorate -- wrong return value
    async def check_valid(self) -> None:
        ...
    
    def not_a_check(self) -> None:
        ...
    
    @check("not checkable return value")
    async def check_invalid_return(self) -> int:
        # Cannot be coerced into a check result
        123
```

Checks are always executed in *method definition order* (or top-to-bottom if you prefer).
This becomes important in a second.

### Required checks

Not all checks are created equal. There are some checks that upon failure imply that all following checks will already have *implicitly failed*. Such checks can be described as **required**.

Consider the example of implementing checks for Kubernetes. The very first thing that it makes sense to do is check if you can connect to the API server (or run `kubectl` in a subprocess). If this check fails, then it makes zero sense to even attempt to check if you can create a Pod, read Deployments, have the required secrets, etc.

To handle these cases, we can combine the notion of a required check with the guarantee of checks executing in method definition order to express these relationships between checks:

```python
class KubernetesChecks(BaseChecks):
    @check("API connectivity", required=True)
    def check_api(self) -> None:
        raise RuntimeError("can't reach API")
    
    @check("read namespace")
    def check_read_namespace(self) -> None:
        ...
    
    @check("has running Pods")
    def check_pods(self) -> None:
        ...
    
    @check("read deployments", required=True)
    def check_read_deployments(self) -> None:
        raise RuntimeError("can't read Deployments")
    
    @check("containers have resource limits")
    def check_resource_limits(self) -> None:
        ...
```

In this example, we have two required checks that act as circuit breakers to halt execution upon failure. If `check_api` fails, then no other checks will be run (more on this in a minute) and you will get a single error to debug. If `check_api` succeeds but `check_read_deployments` fails, then the resource limits won't be checked because if you can't see the Deployment you can't get it to its containers and the requests/limits values.

### New event handler

The check metadata mentioned earlier combines with required checks and the execution order guarantee to provide some very nice capabilities for controlling check execution.

To support these enhancements, the method signature of the `check` event handler has changed:

```python
class NewEventConnector(BaseConnector):
    @on_event()
    async def check(self, 
        filter_: Optional[Filter] = None, 
        halt_on: HaltOnFailed = HaltOnFailed.requirement
    ) -> List[Check]:
        ...
```

There are a few things going on here. We have two new positional parameters: `filter_` and `halt_on`. Let's look at these one at a time.

### Filtering checks

The `filter_` argument is an instance of `servo.checks.Filter` which looks like this (edited down for brevity and clarity):

```python
class Filter(BaseModel):
    name: Union[None, str, Sequence[str], Pattern[str]] = None
    id: Union[None, str, Sequence[str], Pattern[str]] = None
    tags: Optional[Set[str]] = None

    def matches(self, check: Check) -> bool:
        ...
```

These are the same attributes discussed earlier in the check metadata section. The filter matches against checks using AND semantics (all constraints must be satisfied for a match to occur).

The `name` and `id` attributes can be compared against an exact value (type `str`),  a set of possible values (type `Sequence[str]`, which includes lists, sets, and tuples of strings), or evaluated against a regular expression pattern (type `Pattern[str]`).  Values are compared case-sensitively. `id` values are always lowercase alphanumeric characters or `_`.

Tags are evaluated with set intersection semantics (the constraint is satisfied if the check has any tags in common with the filter).

A value of `None` always evaluates positively for the particular constraint.

### Halting check execution

Depending on what you are doing, it can be desirable to handle failing checks differently. You may wish to fail fast to identify a blocked requirement or you may want to run every check and get a sense for how broken your setup is all in.

This is where the `halt_on` parameter comes in. `halt_on` is a value of the `HaltOnFailed`  enumeration which looks like:

```python
class HaltOnFailed(str, enum.Enum):
    """HaltOnFailed is an enumeration that describes how to handle check failures.
    """

    requirement = "requirement"
    """Halt running when a required check has failed.
    """

    check = "check"
    """Halt running when any check has failed.
    """

    never = "never"
    """Never halt running regardless of check failures.
    """
```

Selecting the appropriate `halt_on` value lets you decide how much feedback you want to gather in a given check run.

### CLI upgrades

All of the above changes are pretty hard to utilize without an interface. As such, the servo CLI has been upgraded with some new tricks:

```console
$ servo check --help
Usage: servo check [OPTIONS] [CONNECTORS]...

  Check that the servo is ready to run

Options:
  [CONNECTORS]...                 Connectors to check
  -n, --name TEXT                 Filter by name  [default: False]
  -i, --id TEXT                   Filter by ID  [default: False]
  -t, --tag TEXT                  Filter by tag  [default: False]
  -h, --halt-on-failed [requirement|check|never]
                                  Halt running checks on a failure condition
                                  [default: requirement]

  -v, --verbose                   Display verbose output  [default: False]
  -q, --quiet                     Do not echo generated output to stdout
                                  [default: False]

  --help                          Show this message and exit.
```

Results get aggregated and summarized by connector:

```console
CONNECTOR    STATUS    ERRORS
servo        X FAILED  (1/1) Opsani API connectivity: Response status code: 500
prometheus   √ PASSED
vegeta       √ PASSED
```

We can run a check by name:

```console
$ servo check --name "Check throughput"
CONNECTOR    STATUS    ERRORS
prometheus   √ PASSED
```

Or a set of IDs comma separated:

```console
$ servo check -i "fae728a9, 09b17996" -v
CONNECTOR    CHECK             ID        TAGS    STATUS    MESSAGE
prometheus   Check throughput  fae728a9  -       √ PASSED  returned 1 TimeSeries readings
             Check error_rate  09b17996  -       √ PASSED  returned 0 TimeSeries readings
```

Or every check that contains "exec" (strings in slashes "/like this/" are compiled as regex):

```console
$ servo check -n "/.*exec.+/" -v
CONNECTOR    CHECK             ID               TAGS    STATUS    MESSAGE
vegeta       Vegeta execution  check_execution  -       √ PASSED  Vegeta exit code: 0
```

And set the halting behavior in the face of failures:

```console
$ servo check --halt-on-failed=requirement prometheus

CONNECTOR    STATUS    ERRORS
prometheus   X FAILED  (1/2) Check throughput: caught exception: ConnectError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 9091, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 9091)"))
                       (2/2) Check error_rate: caught exception: ConnectError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 9091, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 9091)"))

$ servo check --halt-on-failed=check prometheus
CONNECTOR    STATUS    ERRORS
prometheus   X FAILED  (1/1) Check throughput: caught exception: ConnectError(OSError("Multiple exceptions: [Errno 61] Connect call failed ('::1', 9091, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 9091)"))
```

### Creating Checks from an Iterable

Sometimes you have a collection of homogenous items that need to be checked. A common example is a list of queries for a metrics provider like Prometheus:

```yaml
prometheus:
  base_url: http://localhost:9091/
  metrics:
  - name: throughput
    query: rate(http_requests_total[1s])[3m]
    unit: rps
  - name: error_rate
    query: rate(errors)
    unit: '%'
  - name: go_threads
    query: gc_info
    unit: threads
  - name: go_memstats_alloc_bytes
    query: go_memstats_alloc_bytes
    unit: bytes
```

We don't want to handwrite a method for each of these and if we just loop over it, we can't use filters to focus on the failure cases -- making debugging slower and noisier.

What we want is the ability to synthesize a checks class without having to write the code by hand:

```python
class PrometheusConnector(BaseConnector):
    config: PrometheusConfiguration

    @on_event()
    async def check(self, 
        filter_: Optional[Filter] = None, 
        halt_on: HaltOnFailed = HaltOnFailed.requirement
    ) -> List[Check]:
        start, end = datetime.now() - timedelta(minutes=10), datetime.now()        
        async def check_query(metric: PrometheusMetric) -> str:
            result = await self._query_prom(metric, start, end)
            return f"returned {len(result)} TimeSeries readings"

        # wrap all queries into checks and verify that they work
        PrometheusChecks = create_checks_from_iterable(check_query, self.config.metrics)
        return await PrometheusChecks.run(self.config, filter_, halt_on=halt_on)
```

Here the `check_query` inner function is going to be used just like earlier examples that were "checkified" via the `@check` decorator and the `self.config.metrics` collection is going to be treated like a list of methods in a `BaseChecks` subclass.

The call to `create_checks_from_iterable` returns a new dynamically created subclass of `BaseChecks` with `check_` instance methods attached for every item in the `self.config.metrics` collection.

The `PrometheusChecks` class behaves exactly like a manually coded checks subclass and can be filtered, etc.

### Checkable Protocol

Protocols are a relatively recent extension to Python that supports *structural subtyping*. This is basically the idea that a class does not have to explicitly inherit from another class in order to be considered its subtype. It is an extension of the concept of duck typing in dynamic languages to the typing system (sometimes called "Static Duck Typing", see [https://www.python.org/dev/peps/pep-0544/](PEP 544)).

The `servo.checks.Checkable` protocol defines a single method called `__check__` that returns a `Check` object. The protocol is used extensively in the internals but can be used as a public API to provide check implementations for arbitrary objects.

### Safe and productive by default

The checks subsystem works really hard to make the easy thing delightful and the wrong impossible. There is extensive enforcement around type hint contracts to avoid typo bugs. The code is extensively documented and covered with tests. 

## Open Questions

### Support async checks in parallel?

The predictable execution path of the revised implementation opens the door to executing more checks in parallel. Right now check events for connectors are parallelized while individual checks are executed serially. Required checks effectively let you partition groups of checks and run them in parallel since you know that they have no interdependencies and their parent dependencies have already been met.

### Does it make sense to promote checks to a top-level concept like configuration?

```python
class TopLevelExample(BaseConnector):
    config: ExampleConfiguration
    checks: ExampleChecks
```

The benefit is eliminating additional boilerplate with the trade-off that the design becomes de-facto more rigid and magical as most folks will never realize that checks built on top of eventing and can be directly customized with an event handler method.

But if I have now covered the 80%+ of cases then most folks would never even need to know.