### PR TITLE
Networking enhancements: backoff, retry, proxies, timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ checks and provide a better operational experience for running and debugging che
 ### Added
 - `servo run --check` will run all configured checks before starting the servo runloop.
 - `servo check` now supports filtering by name, id, and tags. Failure mode handling is configurable via `--halt-on-failed=[requirement,check,never]`
+- `servo run` now applies exponential backoff and retry to recover from transient HTTP errors.
+- Introduce associations mixin for managing off-model support objects that don't make sense to model as attributes.
+- `ServoConfiguration` class for applying settings to the servo itself.
+- HTTP proxy support (configured on `ServoConfiguration`).
+- Timeout configuration (configured on `ServoConfiguration`).
+- Support for configuring backoff and retry behaviors (configured on `ServoConfiguration`).
+
+### Fixed
+- Attempting to connect to an invalid or unavailable optimizer backend now triggers exponential backoff and retry rather than crashing.
+- Encountering an unexpected event error from the optimizer now aborts the operation in progress and resets rather than waiting for the operation to complete.
 
 ## [0.5.1] - 2020-08-23
 

--- a/servo/checks.py
+++ b/servo/checks.py
@@ -630,6 +630,7 @@ def _set_check_result(check: Check, result: Union[None, bool, str, Tuple[bool, s
         check.success = False
         check.exception = result
         check.message = f"caught exception: {repr(result)}"
+        default_logger.exception("error", exception=result)
     else:
         raise ValueError(f"check method returned unexpected value of type \"{result.__class__.__name__}\"")
     

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -32,14 +32,14 @@ from servo.assembly import (
 )
 from servo.connector import (
     BaseConnector, 
-    Optimizer
+    Optimizer,
+    _connector_class_from_string
 )
 from servo.events import EventHandler, EventResult, Preposition
 from servo.logging import logger, set_level as set_log_level
 from servo.servo import (
     Events,
     Servo,
-    _connector_class_from_string
 )
 from servo.checks import Check, Filter, HaltOnFailed
 from servo.runner import Runner
@@ -1559,7 +1559,7 @@ class ServoCLI(CLI):
         ) -> None:
             """Generate a configuration"""
             exclude_unset = not defaults
-            exclude = {"connectors"} if standalone else {}
+            exclude = {"connectors", "servo"} if standalone else {}
 
             routes = (
                 self.connector_routes_callback(context=context, value=connectors)
@@ -1590,7 +1590,7 @@ class ServoCLI(CLI):
                     config.connectors = connectors
             
             config_yaml = config.yaml(
-                by_alias=True, exclude_unset=exclude_unset, exclude=exclude
+                by_alias=True, exclude_unset=exclude_unset, exclude=exclude, exclude_none=True
             )
             if file.exists() and force == False:
                 delete = typer.confirm(f"File '{file}' already exists. Overwrite it?")

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -1590,7 +1590,7 @@ class ServoCLI(CLI):
                     config.connectors = connectors
             
             config_yaml = config.yaml(
-                by_alias=True, exclude_unset=exclude_unset, exclude=exclude, exclude_none=True
+                by_alias=True, exclude_unset=exclude_unset, exclude_defaults=exclude_unset, exclude=exclude, exclude_none=True
             )
             if file.exists() and force == False:
                 delete = typer.confirm(f"File '{file}' already exists. Overwrite it?")

--- a/servo/configuration.py
+++ b/servo/configuration.py
@@ -296,7 +296,10 @@ class ServoConfiguration(BaseConfiguration):
     settings for shared services such as networking and logging.
     """
 
-    backoff: Dict[str, BackoffSettings] = { "connect": { "max_time": "1h" } }
+    backoff: Dict[str, BackoffSettings] = Field({ 
+        "__default__": { "max_time": "10m", "max_tries": None },
+        "connect": { "max_time": "1h", "max_tries": None },
+    })
     """A mapping of named operations to settings for the backoff library, which provides backoff
     and retry capabilities to the servo.
 
@@ -337,6 +340,9 @@ class ServoConfiguration(BaseConfiguration):
     @classmethod
     def generate(cls, **kwargs) -> Optional["ServoConfiguration"]:
         return None
+    
+    class Config:
+        validate_assignment = True
 
 
 class BaseAssemblyConfiguration(BaseConfiguration, abc.ABC):

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -425,7 +425,6 @@ class KubernetesModel(abc.ABC):
             True if in the ready state; False otherwise.
         """
     
-    # TODO: Add Duration support
     async def wait_until_ready(
             self,
             timeout: int = None,
@@ -462,7 +461,6 @@ class KubernetesModel(abc.ABC):
             fail_on_api_error=fail_on_api_error,
         )
     
-    # TODO: Add Duration support
     async def wait_until_deleted(self, timeout: int = None, interval: Union[int, float] = 1) -> None:
         """Wait until the resource is deleted from the cluster.
 
@@ -898,7 +896,7 @@ class Pod(KubernetesModel):
     
     async def patch(self) -> None:
         """
-        TODO: Add docs....
+        Patches a Pod, applying spec changes to the cluster.
         """
         self.logger.info(f'patching pod "{self.name}"')
         self.logger.trace(f'pod: {self.obj}')
@@ -1013,7 +1011,6 @@ class Pod(KubernetesModel):
 
         return self.containers
 
-    # TODO: Rename `find_container` ??
     def get_container(self, name: str) -> Union[Container, None]:
         """Get a container in the Pod by name.
 
@@ -1265,15 +1262,6 @@ class Deployment(KubernetesModel):
             return False
 
         return total == ready
-    
-    # TODO: Determine if we want this...
-    def is_complete(self, target_generation: int) -> bool:
-        # Kubernetes marks a Deployment as complete when it has the following characteristics:
-
-        # All of the replicas associated with the Deployment have been updated to the latest version you've specified, meaning any updates you've requested have been completed.
-        # All of the replicas associated with the Deployment are available.
-        # No old replicas for the Deployment are running.
-        ...
 
     @property
     def containers(self) -> List[Container]:
@@ -2380,7 +2368,7 @@ class DeploymentConfiguration(BaseKubernetesConfiguration):
 
 class KubernetesConfiguration(BaseKubernetesConfiguration):
     namespace: DNSSubdomainName = DNSSubdomainName("default")
-    timeout: Duration = "5m" # TODO: TypeError: __new__() takes from 1 to 2 positional arguments but 4 were given
+    timeout: Duration = "5m"
   
     deployments: List[DeploymentConfiguration] = Field(
         description="Deployments to be optimized.",
@@ -2554,17 +2542,6 @@ class KubernetesConnector(BaseConnector):
 
     @on_event()
     async def adjust(self, adjustments: List[Adjustment], control: Control = Control()) -> None:
-        # TODO: Handle this adjust_on stuff (Do we even need this???)
-        # adjust_on = desc.get("adjust_on", False)
-
-        # if adjust_on:
-        #     try:
-        #         should_adjust = eval(adjust_on, {"__builtins__": None}, {"data": data})
-        #     except:
-        #         should_adjust = False
-        #     if not should_adjust:
-        #         return {"status": "ok", "reason": "Skipped due to 'adjust_on' condition"}
-
         state = await KubernetesOptimizations.create(self.config)
         await state.apply(adjustments)
 

--- a/servo/logging.py
+++ b/servo/logging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 import functools
+import logging
 import sys
 import time
 import traceback
@@ -129,6 +130,23 @@ class ProgressHandler:
                 self._error_reporter(message)
 
 
+class InterceptHandler(logging.Handler):
+    def emit(self, record):
+        # Get corresponding Loguru level if it exists
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find caller from where originated the logged message
+        frame, depth = logging.currentframe(), 2
+        while frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
 DEFAULT_FORMAT = (
     "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
     "<level>{level: <8}</level> | "
@@ -214,6 +232,10 @@ def reset_to_defaults() -> loguru.Logger:
     logger.remove()
     logger.configure(handlers=DEFAULT_HANDLERS)
     DEFAULT_FILTER.level = "INFO"
+
+    # Intercept messages from backoff library
+    logging.getLogger('backoff').addHandler(InterceptHandler())
+
     return logger
 
 def friendly_decorator(f):

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 import signal
+import logging
 from typing import Any, Dict, List, Optional, Union
 
 import backoff
@@ -13,8 +14,8 @@ from pydantic import BaseModel, Field, parse_obj_as
 
 from servo import api
 from servo.api import descriptor_to_adjustments
-from servo.assembly import Assembly, BaseServoConfiguration
-from servo.configuration import Optimizer
+from servo.assembly import Assembly
+from servo.configuration import BaseAssemblyConfiguration, Optimizer
 from servo.errors import ConnectorError
 from servo.logging import ProgressHandler
 from servo.servo import Events, Servo
@@ -38,7 +39,7 @@ class Runner(api.Mixin):
         return self.assembly.servo
 
     @property
-    def config(self) -> BaseServoConfiguration:
+    def config(self) -> BaseAssemblyConfiguration:
         return self.servo.config
 
     @property

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field, parse_obj_as
 from servo import api
 from servo.api import descriptor_to_adjustments
 from servo.assembly import Assembly
-from servo.configuration import BaseAssemblyConfiguration, Optimizer
+from servo.configuration import BaseAssemblyConfiguration, Optimizer, ServoConfiguration
 from servo.errors import ConnectorError
 from servo.logging import ProgressHandler
 from servo.servo import Events, Servo
@@ -23,11 +23,51 @@ from servo.types import Adjustment, Control, Duration, Description, Measurement
 from servo.utilities import commandify, value_for_key_path
 
 
+DEFAULT_CONTEXT = "__default__"
+
+
+class BackoffConfig:
+    """BackoffConfig provides callables for runtime configuration of backoff decorators.
+
+    This implementation relies upon the framework managed context variables to determine
+    which servo is running and retrieve the configuration.
+    """
+
+    @staticmethod
+    def max_time(context: str = DEFAULT_CONTEXT) -> Optional[int]:
+        if servo_config := Servo.current().config.servo:
+            if backoff_config := servo_config.backoff.get(context, None):
+                if max_time := backoff_config.max_time:
+                    return max_time.total_seconds()
+        
+        # fallback to default
+        if max_time := BackoffConfig.max_time():
+            return max_time
+        
+        raise AssertionError("max_time default should never be None")
+
+    
+    @staticmethod
+    def max_tries(context: str = DEFAULT_CONTEXT) -> Optional[int]:
+        if servo_config := Servo.current().config.servo:
+            if backoff_config := servo_config.backoff.get(context, None):
+                return backoff_config.max_tries
+        
+        # fallback to default
+        return BackoffConfig.max_tries()
+
+
 class Runner(api.Mixin):
     assembly: Assembly
+    connected: bool = False
 
     def __init__(self, assembly: Assembly) -> None:
         self.assembly = assembly
+
+        # initialize default servo options if not configured
+        if self.config.servo is None:
+            self.config.servo = ServoConfiguration()
+
         super().__init__()
 
     @property
@@ -114,6 +154,8 @@ class Runner(api.Mixin):
         await self.servo.dispatch_event(Events.ADJUST, adjustments)
         self.logger.info(f"Adjustment completed {summary}")
 
+    # backoff and retry for an hour on transient request failures
+    @backoff.on_exception(backoff.expo, httpx.HTTPError, max_time=BackoffConfig.max_time)
     async def exec_command(self):
         cmd_response = await self._post_event(api.Event.WHATS_NEXT, None)
         self.logger.info(f"What's Next? => {cmd_response.command}")
@@ -174,10 +216,11 @@ class Runner(api.Mixin):
         except Exception as error:            
             self.logger.exception(f"{cmd_response.command} command failed: {error}")
             # TODO: we need to track connectivity state instead of trying to blindly send
-            # param = dict(status="failed", message=str(error))
-            # await self._post_event(cmd_response.command.response_event, param)
+            if self.connected:
+                param = dict(status="failed", message=str(error))
+                await self._post_event(cmd_response.command.response_event, param)
             raise
-
+        
     async def main(self) -> None:
         # Setup logging
         self.progress_handler = ProgressHandler(self.servo.report_progress, self.logger.warning)
@@ -186,11 +229,31 @@ class Runner(api.Mixin):
         self.logger.info(
             f"Servo started with {len(self.servo.connectors)} active connectors [{self.optimizer.id} @ {self.optimizer.base_url}]"
         )
-        self.logger.info("Dispatching startup event...")
-        await self.servo.startup()
 
-        self.logger.info("Saying HELLO.", end=" ")
-        await self._post_event(api.Event.HELLO, dict(agent=api.USER_AGENT))
+        async def giveup(details) -> None:
+            loop = asyncio.get_event_loop()
+            self.logger.critical("retries exhausted, giving up")
+            asyncio.create_task(self.shutdown(loop))
+
+        try:
+            @backoff.on_exception(
+                backoff.expo, 
+                httpx.HTTPError, 
+                max_time=lambda: BackoffConfig.max_time("connect"),
+                on_giveup=giveup
+            )
+            async def connect() -> None:                
+                self.logger.info("Saying HELLO.", end=" ")
+                await self._post_event(api.Event.HELLO, dict(agent=api.USER_AGENT))
+                self.connected = True
+
+            self.logger.info("Dispatching startup event...")
+            await self.servo.startup()
+
+            self.logger.info("Connecting to Opsani optimizer API...")
+            await connect()
+        except:
+            pass
 
         while True:
             await self.exec_command()
@@ -200,9 +263,9 @@ class Runner(api.Mixin):
             self.logger.info(f"Received exit signal {signal.name}...")
 
         try:
-            # TODO: Track connection state. Can't report GOODBYE if HELLO never succeeded
-            reason = signal.name if signal else 'shutdown'
-            await self._post_event(api.Event.GOODBYE, dict(reason=reason))
+            if self.connected:
+                reason = signal.name if signal else 'shutdown'
+                await self._post_event(api.Event.GOODBYE, dict(reason=reason))
         except Exception:
             self.logger.exception(f"Exception occurred during GOODBYE request")
         
@@ -254,4 +317,6 @@ class Runner(api.Mixin):
             loop.create_task(self.main())
             loop.run_forever()
         finally:
-            loop.close()            
+            loop.close()
+
+    

--- a/servo/utilities/associations.py
+++ b/servo/utilities/associations.py
@@ -1,0 +1,70 @@
+"""Associations are virtual attributes maintained outside of an object instance.
+
+Associations provide the ability to manage state for an object without polluting
+its namespace. They are very useful for supporting Pydantic models without 
+introducing new attributes that need to be considered in the schema and validation
+logic.
+"""
+
+from typing import Any, Dict, Protocol, runtime_checkable
+from weakref import WeakKeyDictionary
+
+_associations = WeakKeyDictionary()
+
+class Mixin:
+    def __init__(self, *args, **kwargs) -> None:
+        # NOTE: we are not hashable until after init
+        super().__init__(*args, **kwargs)
+        _associations[self] = {}
+
+    def _set_association(self, name: str, obj: Any) -> None:
+        """Sets an object association by name.
+
+        Args:
+            name: A name for the association.
+            obj: The object to associate with.
+        """
+        _associations[self][name] = obj
+
+
+    def _get_association(self, name: str, default: Any = ...) -> Any:
+        """Returns an associated object by name.
+
+        Args:
+            name: The name of the association to retrieve.
+            default: A default value to return instead of raising a `KeyError` if
+                the association cannot be found.
+
+        Returns:
+            The associated object.
+
+        Raises:
+            KeyError: Raised if there is no associated object with the given name.
+        """
+        if default == ...:
+            return _associations[self][name]
+        else:
+            return _associations[self].get(name, default)
+    
+    @property
+    def _associations(self) -> Dict[str, Any]:
+        """Returns all associated objects as dictionary.
+
+        Returns:
+            A dictionary mapping of associated object names and values.
+        """
+        return _associations[self]#.copy()
+    
+
+@runtime_checkable
+class Associative(Protocol):
+    """
+    Associative is a protocol that describes objects that support associations.
+    """
+    def _set_association(self, name: str, obj: Any) -> None:
+        ...
+    def _get_association(self, name: str, default: Any = ...) -> Any:
+        ...
+    def _associations(self) -> Dict[str, Any]:
+        ...
+    

--- a/servo/utilities/key_paths.py
+++ b/servo/utilities/key_paths.py
@@ -30,5 +30,4 @@ def value_for_key_path(obj: object, key_path: str, default: Any = DEFAULT_SENTIN
         if default is not DEFAULT_SENTINEL:
             return default
         else:
-            debug(default)
             raise ValueError(f"unknown key-path '{key_path}'")

--- a/servo/utilities/pydantic.py
+++ b/servo/utilities/pydantic.py
@@ -1,5 +1,7 @@
-from typing import Any, Callable, Type
+from contextlib import contextmanager
+from typing import Any, Callable, Generator, Type
 
+from pydantic import BaseModel, Extra
 from pydantic.validators import _VALIDATORS
 
 
@@ -17,3 +19,12 @@ def append_pydantic_validator(
     for _validator in _VALIDATORS:
         if _validator[0] == type_:
             _validator[1].append(validator)
+
+@contextmanager
+def extra(obj: BaseModel, extra: Extra = Extra.allow) -> Generator[BaseModel, None, None]:
+    """Temporarily overrides the value of the `extra` setting on a Pydantic model.
+    """
+    original = obj.__config__.extra
+    obj.__config__.extra = extra
+    yield obj
+    obj.__config__.extra = original

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os
 import random
 import string
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 import pytest
 import yaml
@@ -12,16 +12,14 @@ from typer.testing import CliRunner
 # Add the devtools debug() function globally in tests
 try:
     import builtins
-
     from devtools import debug
+
+    builtins.debug = debug
 except ImportError:
     pass
-else:
-    builtins.debug = debug
 
 from servo.configuration import Optimizer
 from servo.cli import ServoCLI
-# Force the test connectors to load early
 from tests.test_helpers import StubBaseConfiguration, SubprocessTestHelper
 
 
@@ -65,7 +63,7 @@ def servo_cli() -> ServoCLI:
 
 
 @pytest.fixture()
-def optimizer_env() -> None:
+def optimizer_env() -> Iterator[None]:
     os.environ.update(
         {"OPSANI_OPTIMIZER": "dev.opsani.com/servox", "OPSANI_TOKEN": "123456789"}
     )

--- a/tests/connector_test.py
+++ b/tests/connector_test.py
@@ -15,8 +15,8 @@ from typer.testing import CliRunner
 
 from servo import Duration
 from servo.cli import ServoCLI
+from servo.configuration import BaseAssemblyConfiguration, BaseConfiguration
 from servo.connector import (
-    BaseConfiguration,
     BaseConnector,
     License,
     Maturity,
@@ -24,7 +24,6 @@ from servo.connector import (
     Version,
     _connector_subclasses,
 )
-from servo.assembly import BaseServoConfiguration
 from servo.connectors.vegeta import TargetFormat, VegetaConfiguration, VegetaConnector
 from servo.events import EventContext, Preposition, _events, create_event, event
 from servo.logging import ProgressHandler, reset_to_defaults
@@ -661,7 +660,7 @@ def test_env_variable_prefixing() -> None:
     schemas = [
         BaseConfiguration.schema(),
         VegetaConfiguration.schema(),
-        BaseServoConfiguration.schema(),
+        BaseAssemblyConfiguration.schema(),
     ]
     # NOTE: popping the env_names without copying is a mistake you will only make once
     values = list(
@@ -974,7 +973,6 @@ def test_vegeta_cli_generate_with_defaults(
     config_file = tmp_path / "vegeta.yaml"
     config = yaml.full_load(config_file.read_text())
     assert config == {
-        "description": None,
         "vegeta": {
             "connections": 10000,
             "description": "Update the rate, duration, and target/targets to match your load profile",
@@ -988,7 +986,6 @@ def test_vegeta_cli_generate_with_defaults(
             "rate": "50/1s",
             "reporting_interval": "15s",
             "target": "GET https://example.com/",
-            "targets": None,
             "workers": 10,
         },
     }

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -840,8 +840,13 @@ class TestAssembly:
                     'backoff': {
                         'title': 'Backoff',
                         'default': {
+                            '__default__': {
+                                'max_time': '10m',
+                                'max_tries': None,
+                            },
                             'connect': {
                                 'max_time': '1h',
+                                'max_tries': None,
                             },
                         },
                         'env_names': [
@@ -1620,3 +1625,12 @@ async def test_httpx_client_config() -> None:
             assert client.proxies["all"]
             assert client.transport._ssl_context.verify_mode == ssl.CERT_NONE
             assert client.transport._ssl_context.check_hostname == False
+
+
+def test_backoff_defaults() -> None:
+    config = ServoConfiguration()
+    assert config.backoff
+    assert config.backoff["__default__"]
+    assert config.backoff["__default__"].max_time is not None
+    assert config.backoff["__default__"].max_time == Duration("10m")
+    assert config.backoff["__default__"].max_tries is None

--- a/tests/utilities/associations_test.py
+++ b/tests/utilities/associations_test.py
@@ -1,0 +1,37 @@
+import pytest
+from servo.utilities.associations import Mixin, Associative
+
+class AssociativeObject(Mixin):
+    pass
+
+def test_association_init() -> None:
+    obj = AssociativeObject()
+    assert obj._associations == {}
+
+def test_set_association() -> None:
+    obj = AssociativeObject()
+    obj._set_association("foo", 123)
+    assert obj._associations == {"foo": 123}
+
+def test_get_association() -> None:
+    obj = AssociativeObject()
+    obj._set_association("foo", 123)
+    assert obj._get_association("foo") == 123
+
+def test_get_association_unknown() -> None:
+    obj = AssociativeObject()
+    with pytest.raises(KeyError):
+        obj._get_association("invalid")
+
+def test_get_association_default() -> None:
+    obj = AssociativeObject()
+    assert obj._get_association("unknown", 1234) == 1234
+
+def test_associations() -> None:
+    obj = AssociativeObject()
+    assert obj._associations is not None
+    assert obj._associations == {}
+
+def test_associative_protocol() -> None:
+    obj = AssociativeObject()
+    assert isinstance(obj, Associative)


### PR DESCRIPTION
This PR introduces a number of enhancements to enable the servo to operate in challenging environments and gracefully handle transient errors. It also introduces a new `servo` configuration stanza for settings that apply to functionality provided by the library to all connectors.

Specific changes include:

* `servo` configuration stanza
* timeouts are now configurable for connect, read, write, and acquiring a connection from the pool
* SSL is now configurable. Verification can be disabled (but please don't do this) and non-validating SSL certificate chains from private PKI can be loaded
* Proxies can be configured for connecting to the Opsani API or any other web service as necessary
* Introduced associated objects API for managing supporting objects that don't need to be exposed as attributes

There is an early-stage implementation of connectivity awareness so that the servo does not attempt operations that are guaranteed to fail. This immediately cuts down on debugging noise but is likely to evolve into a state machine that allows the servo to track and report on what it has going on