### PR TITLE
Feature/k8s resource limit min

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2126,7 +2126,7 @@ class KubernetesAdjustment(servo.Adjustment):
         else:
             raise NotImplementedError(
                     f"missing error normalization logic for setting '{setting}'"
-                ) 
+                )
 
         for value in values:
             ret_values.append(parse_val(value))

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2371,7 +2371,8 @@ class DeploymentOptimization(BaseOptimization):
         to enable aggregation of related adjustments and asynchronous application.
         """
         setting_name, value = adjustment.normalize_adjustment()
-        self.logger.info(f"adjusting {setting_name} to {value.human_readable()}")
+        log_val = value.human_readable() if isinstance(value, (Millicore, ShortByteSize)) else value
+        self.logger.info(f"adjusting {setting_name} to {log_val}")
 
         if setting_name in ("cpu", "memory"):
             # NOTE: Assign to the config to trigger validations
@@ -2517,7 +2518,8 @@ class CanaryOptimization(BaseOptimization):
 
     def adjust(self, adjustment: KubernetesAdjustment, control: servo.Control = servo.Control()) -> None:
         setting_name, value = adjustment.normalize_adjustment()
-        self.logger.info(f"adjusting {setting_name} to {value.human_readable()}")
+        log_val = value.human_readable() if isinstance(value, (Millicore, ShortByteSize)) else value
+        self.logger.info(f"adjusting {setting_name} to {log_val}")
 
         if setting_name in ("cpu", "memory"):
             setting = getattr(self.target_container_config, setting_name)

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2033,7 +2033,7 @@ class CPU(servo.CPU):
         #   so require it to be configured as `compute` to prevent unintended modifications
         if values.get('limit_min') is not None and values.get('requirements') != ResourceRequirements.compute:
             raise ValueError('Configuration of limit_min only supported on `compute` requirement as both requirements are updated in adjustment')
-        
+
         return values
 
     def __opsani_repr__(self) -> dict:
@@ -2091,7 +2091,7 @@ class Memory(servo.Memory):
         #   so require it to be configured as `compute` to prevent unintended modifications
         if values.get('limit_min') is not None and values.get('requirements') != ResourceRequirements.compute:
             raise ValueError('Configuration of limit_min only supported on `compute` requirement as both requirements are updated in adjustment')
-        
+
         return values
 
     def __opsani_repr__(self) -> dict:

--- a/servo/types.py
+++ b/servo/types.py
@@ -18,6 +18,7 @@ from typing import (
     List,
     Optional,
     Protocol,
+    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -1417,7 +1418,7 @@ class Adjustment(BaseModel):
     """The name of the setting to be adjusted.
     """
 
-    value: Union[str, Numeric]
+    value: Union[str, Numeric, Sequence[Union[str, Numeric]]]
     """The value to be applied to the setting being adjusted.
     """
 

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -900,7 +900,7 @@ class TestKubernetesConnectorIntegration:
         connector = KubernetesConnector(config=config)
         description = await connector.describe()
         assert description.get_setting("fiber-http/fiber-http.cpu").value == 50
-        assert description.get_setting("fiber-http/fiber-http.mem").human_readable_value == "64.0MiB"
+        assert description.get_setting("fiber-http/fiber-http.mem").human_readable_value == "64.0Mi"
         assert description.get_setting("fiber-http/fiber-http.replicas").value == 1
 
     async def test_adjust_cpu(self, config):

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -980,7 +980,7 @@ class TestKubernetesConnectorIntegration:
         setting = description.get_setting('fiber-http/fiber-http.mem')
         assert setting
         assert setting.value.human_readable() == "64.0Mi"
-        
+
         deployments = kube.get_deployments()
         fiber_deploy = deployments.get("fiber-http")
         fiber_container = next(iter(c for c in fiber_deploy.obj.spec.template.spec.containers if c.name == 'fiber-http'))
@@ -996,7 +996,7 @@ class TestKubernetesConnectorIntegration:
         setting = description.get_setting('fiber-http/fiber-http.mem')
         assert setting
         assert setting.value.human_readable() == "256.0Mi"
-        
+
         deployments = kube.get_deployments()
         fiber_deploy = deployments.get("fiber-http")
         fiber_container = next(iter(c for c in fiber_deploy.obj.spec.template.spec.containers if c.name == 'fiber-http'))
@@ -1015,7 +1015,7 @@ class TestKubernetesConnectorIntegration:
         setting = description.get_setting('fiber-http/fiber-http.cpu')
         assert setting
         assert setting.value.human_readable() == '50m'
-        
+
         deployments = kube.get_deployments()
         fiber_deploy = deployments.get("fiber-http")
         fiber_container = next(iter(c for c in fiber_deploy.obj.spec.template.spec.containers if c.name == 'fiber-http'))
@@ -1031,7 +1031,7 @@ class TestKubernetesConnectorIntegration:
         setting = description.get_setting('fiber-http/fiber-http.cpu')
         assert setting
         assert setting.value.human_readable() == '175m'
-        
+
         deployments = kube.get_deployments()
         fiber_deploy = deployments.get("fiber-http")
         fiber_container = next(iter(c for c in fiber_deploy.obj.spec.template.spec.containers if c.name == 'fiber-http'))

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -793,6 +793,7 @@ class TestMemory:
             "max": 4294967296,
             "step": 268435456,
             "value": None,
+            "limit_min": None,
             "pinned": False,
             "requirements": ResourceRequirements.compute,
         } == memory.dict()
@@ -831,9 +832,9 @@ class TestMemory:
 
     def test_resources_encode_to_json_human_readable(self, memory) -> None:
         serialization = json.loads(memory.json())
-        assert serialization["min"] == "128.0MiB"
-        assert serialization["max"] == "4.0GiB"
-        assert serialization["step"] == "256.0MiB"
+        assert serialization["min"] == "128.0Mi"
+        assert serialization["max"] == "4.0Gi"
+        assert serialization["step"] == "256.0Mi"
 
 def test_millicpu():
     class Model(pydantic.BaseModel):

--- a/tests/connectors/opsani_dev_test.py
+++ b/tests/connectors/opsani_dev_test.py
@@ -66,9 +66,9 @@ class TestConfig:
             "  max: '4'\n"
             "  step: 125m\n"
             "memory:\n"
-            "  min: 256.0MiB\n"
-            "  max: 4.0GiB\n"
-            "  step: 128.0MiB\n"
+            "  min: 256.0Mi\n"
+            "  max: 4.0Gi\n"
+            "  step: 128.0Mi\n"
         )
 
 

--- a/tests/integration/cli_test.py
+++ b/tests/integration/cli_test.py
@@ -56,7 +56,7 @@ async def test_generate_opsani_dev(project_path: pathlib.Path, subprocess) -> No
             "    max: '4'\n"
             "    step: 125m\n"
             "  memory:\n"
-            "    min: 256.0MiB\n"
-            "    max: 4.0GiB\n"
-            "    step: 128.0MiB\n"
+            "    min: 256.0Mi\n"
+            "    max: 4.0Gi\n"
+            "    step: 128.0Mi\n"
         )


### PR DESCRIPTION
Support for a new  `limit_min` configuration property of the CPU and Memory models. Only supported with `ResourceRequirements.compute` (equivalent of legacy `both` option). 

When set, the corresponding resource limit will only be set to the adjust value if said value is greater than the configured `limit_min`. Otherwise, limit will be set to the configured value of `limit_min`.

Note accommodating this change opened a bit of a can of worms as the adjust values were not being cast into comparable types prior to being fed into the containers. I'm hopeful any side effects are minor and can be quickly fixed but I am open to alternative implementations