### PR TITLE
Fix overriding of subconfig timeout SOL-220

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2425,6 +2425,7 @@ class DeploymentOptimization(BaseOptimization):
                 deployment=deployment,
                 container_config=container_config,
                 container=container,
+                timeout=config.timeout,
                 **kwargs,
             )
 
@@ -2628,6 +2629,7 @@ class CanaryOptimization(BaseOptimization):
                 target_container=target_container,
                 tuning_pod=tuning_pod,
                 tuning_container=tuning_container,
+                timeout=config.timeout,
                 **kwargs,
             )
 

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1023,7 +1023,7 @@ class TestKubernetesConnectorIntegration:
         namespace
     ) -> None:
         # debug("SETTING TIMEOUT TO 2s")
-        tuning_config.deployments[0].timeout = "2s" # TODO; will likely need to bump this, was too low on local minkube cluster 
+        tuning_config.deployments[0].timeout = "7s"
         # for deployment_config in tuning_config.deployments:
         #     deployment_config.timeout = "2s"
         # debug("SET TIMEOUT TO 2s: ", tuning_config.timeout)

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -972,7 +972,7 @@ class TestKubernetesConnectorIntegration:
         # debug(deployment.obj.spec.template.spec.containers)
 
     async def test_adjust_deployment_insufficient_resources(self, config: KubernetesConfiguration):
-        config.timeout = "3s"
+        config.deployments[0].timeout = "3s"
         config.deployments[0].containers[0].memory.max = "256Gi"
         connector = KubernetesConnector(config=config)
 
@@ -1135,7 +1135,7 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
 
     async def test_adjust_never_ready(self, config, kube: kubetest.client.TestClient) -> None:
         # new_dep = kube.load_deployment(abspath("../manifests/fiber-http-opsani-dev.yaml")) Why doesn't this work???? Had to use apply_manifests instead
-        config.timeout = "5s"
+        config.deployments[0].timeout = "5s"
         connector = KubernetesConnector(config=config)
 
         adjustment = Adjustment(

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1023,7 +1023,7 @@ class TestKubernetesConnectorIntegration:
         namespace
     ) -> None:
         # debug("SETTING TIMEOUT TO 2s")
-        tuning_config.timeout = "2s"
+        tuning_config.deployments[0].timeout = "2s" # TODO; will likely need to bump this, was too low on local minkube cluster 
         # for deployment_config in tuning_config.deployments:
         #     deployment_config.timeout = "2s"
         # debug("SET TIMEOUT TO 2s: ", tuning_config.timeout)


### PR DESCRIPTION
Resolves #153 

* Reference configs instead of self.timeout
* Don't pass parent config timeout to child config obj create