### PR TITLE
Add hints for step aligned min/max, allow step_alignment to work with offset min

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2197,6 +2197,9 @@ GiB = 2 ** 30
 class ShortByteSize(pydantic.ByteSize):
     """Kubernetes omits the 'B' suffix for some reason"""
 
+    # TODO: ByteSize.human_readable truncates 4.125GiB to 4.1GiB.
+    #   is it worth overriding to get the .125 to show but also have .000 appended to iteger values?
+
     @classmethod
     def validate(cls, v: pydantic.StrIntFloat) -> "ShortByteSize":
         if isinstance(v, str):

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -774,14 +774,14 @@ class TestMillicore:
 class TestMemory:
     @pytest.fixture
     def memory(self) -> Memory:
-        return Memory(min="128 MiB", max="4.0 GiB", step="0.25 GiB")
+        return Memory(min="128 MiB", max="4.125 GiB", step="0.25 GiB")
 
     def test_parsing(self, memory) -> None:
         assert {
             "name": "mem",
             "type": "range",
             "min": 134217728,
-            "max": 4294967296,
+            "max": 4429185024,
             "step": 268435456,
             "value": None,
             "pinned": False,
@@ -792,7 +792,7 @@ class TestMemory:
         memory.value = "3.0 GiB"
         assert memory.__opsani_repr__() == {
             "mem": {
-                "max": 4.0,
+                "max": 4.125,
                 "min": 0.125,
                 "step": 0.25,
                 "value": 3.0,
@@ -815,15 +815,15 @@ class TestMemory:
         }
 
     def test_resolving_equivalent_units(self) -> None:
-        memory = Memory(min="128 MiB", max=4.0, step=268435456)
+        memory = Memory(min="128 MiB", max=4.125, step=268435456)
         assert memory.min == 134217728
-        assert memory.max == 4294967296
+        assert memory.max == 4429185024
         assert memory.step == 268435456
 
     def test_resources_encode_to_json_human_readable(self, memory) -> None:
         serialization = json.loads(memory.json())
         assert serialization["min"] == "128.0MiB"
-        assert serialization["max"] == "4.0GiB"
+        assert serialization["max"] == "4.1GiB"
         assert serialization["step"] == "256.0MiB"
 
     def test_cannot_be_less_than_128MiB(self) -> None:

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -565,13 +565,13 @@ class TestRangeSetting:
                 1.0,
                 11.0,
                 3.0,
-                "RangeSetting('invalid' 1.0-11.0, 3.0) max is not step aligned: 11.0 is not a multiple of 3.0",
+                "RangeSetting('invalid' 1.0-11.0, 3.0) is not step aligned: min max difference 10.0 is not a multiple of 3.0. closest values are min: (0.0 , 2.0) max: (10.0 , 12.0)",
             ),
             (
                 3.0,
                 12.0,
                 2.0,
-                "RangeSetting('invalid' 3.0-12.0, 2.0) min is not step aligned: 3.0 is not a multiple of 2.0",
+                "RangeSetting('invalid' 3.0-12.0, 2.0) min 3.0 is not a multiple of step 2.0 or vice versa",
             ),
         ],
     )
@@ -583,6 +583,7 @@ class TestRangeSetting:
                 RangeSetting(name="invalid", min=min, max=max, step=step)
 
             assert error
+            print(error)
             assert "1 validation error for RangeSetting" in str(error.value)
             assert error.value.errors()[0]["loc"] == ("__root__",)
             assert error.value.errors()[0]["type"] == "value_error"
@@ -594,24 +595,24 @@ class TestRangeSetting:
         ("min", "max", "step", "error_message"),
         [
             (1, 5, 1, None),
-            (1.0, 6.0, 2.0, None),
+            (2.0, 6.0, 2.0, None),
             (
-                1.0,
                 2,
                 3,
+                1.0,
+                "invalid range: min, max, and step must all be of the same Numeric type (int: min, max. float: step.)",
+            ),
+            (
+                2.0,
+                3,
+                1,
                 "invalid range: min, max, and step must all be of the same Numeric type (float: min. int: max, step.)",
             ),
             (
-                1,
-                2.0,
-                3,
-                "invalid range: min, max, and step must all be of the same Numeric type (int: min, step. float: max.)",
-            ),
-            (
-                1,
                 2,
                 3.0,
-                "invalid range: min, max, and step must all be of the same Numeric type (int: min, max. float: step.)",
+                1,
+                "invalid range: min, max, and step must all be of the same Numeric type (int: min, step. float: max.)",
             ),
         ],
     )


### PR DESCRIPTION
- change order of parsing step and max so max can validate against step
-  add validation error if step is greater than max
- update step alignment validation to account for offset min
- add hints for closes min max values if not step aligned