### PR TITLE
Add --interactive and --no-poll modes for servo run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   optimization begins.
 - Introduced pub/sub transformers for filtering, splitting, and aggregating
   messages across channels. [#191](https://github.com/opsani/servox/pull/191)
+- Added `--no-poll` and `--interactive` options to the `servo run` command.
+  [#192](https://github.com/opsani/servox/pull/192)
 
 ### Fixed
 

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -1148,6 +1148,17 @@ class ServoCLI(CLI):
                 help="Verify all checks pass before running",
                 envvar="SERVO_RUN_CHECK",
             ),
+            no_poll: Optional[bool] = typer.Option(
+                None,
+                "--no-poll",
+                help="Do not poll the Opsani API for commands",
+            ),
+            interactive: Optional[bool] = typer.Option(
+                None,
+                "--interactive",
+                "-i",
+                help="Ask for confirmation before executing operations",
+            ),
         ) -> None:
             """
             Run the servo
@@ -1159,7 +1170,8 @@ class ServoCLI(CLI):
                 )
 
             if context.assembly:
-                servo.runner.AssemblyRunner(context.assembly).run()
+                poll = not no_poll
+                servo.runner.AssemblyRunner(context.assembly).run(poll=poll, interactive=bool(interactive))
             else:
                 raise typer.Abort("failed to assemble servo")
 

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -23,6 +23,7 @@ from servo.servo import _set_current_servo
 
 
 class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
+    interactive: bool = False
     _servo: servo.Servo = pydantic.PrivateAttr(None)
     _connected: bool = pydantic.PrivateAttr(False)
     _running: bool = pydantic.PrivateAttr(False)
@@ -31,8 +32,8 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
     class Config:
         arbitrary_types_allowed = True
 
-    def __init__(self, servo_: servo) -> None: # noqa: D10
-        super().__init__()
+    def __init__(self, servo_: servo, **kwargs) -> None: # noqa: D10
+        super().__init__(**kwargs)
         self._servo = servo_
 
         # initialize default servo options if not configured
@@ -183,6 +184,12 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
 
         while self._running:
             try:
+                if self.interactive:
+                    if not typer.confirm("Poll for next command?"):
+                        typer.echo("Sleeping for 1m")
+                        await asyncio.sleep(60)
+                        continue
+
                 status = await self.exec_command()
                 if status.status == servo.api.OptimizerStatuses.unexpected_event:
                     self.logger.warning(
@@ -206,9 +213,8 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
 
         def _reraise_if_necessary(task: asyncio.Task) -> None:
             try:
-                task.result()
-            except asyncio.CancelledError:
-                raise  # Don't log cancellation errors, just propogate.
+                if not task.cancelled():
+                    task.result()
             except Exception as error:  # pylint: disable=broad-except
                 self.logger.error(f"Exiting from servo main loop do to error: {error} (task={task})")
                 self.logger.opt(exception=error).trace(f"Exception raised by task {task}")
@@ -217,7 +223,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
         self._main_loop_task = asyncio.create_task(self.main_loop(), name=f"main loop for servo {self.optimizer.id}")
         self._main_loop_task.add_done_callback(_reraise_if_necessary)
 
-    async def run(self) -> None:
+    async def run(self, *, poll: bool = True) -> None:
         self._running = True
 
         _set_current_servo(self.servo)
@@ -246,14 +252,24 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
 
 
             self.logger.info(f"Connecting to Opsani Optimizer @ {self.optimizer.url}...")
+            if self.interactive:
+                typer.confirm("Connect to the optimizer?", abort=True)
+
             await connect()
+        except typer.Abort:
+            # Rescue abort and notify user
+            servo.logger.warning("Operation aborted. Use Control-C to exit")
+            pass
         except asyncio.CancelledError as error:
             self.logger.opt(exception=error).trace("task cancelled, aborting servo runner")
             raise error
         except:
             self.logger.exception("exception encountered during connect")
 
-        self.run_main_loop()
+        if poll:
+            self.run_main_loop()
+        else:
+            self.logger.warning(f"Servo runner initialized with polling disabled -- command loop is not running")
 
     async def shutdown(self, *, reason: Optional[str] = None) -> None:
         """Shutdown the running servo."""
@@ -288,7 +304,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
     def running(self) -> bool:
         return self._running
 
-    def run(self) -> None:
+    def run(self, *, poll: bool = True, interactive: bool = False) -> None:
         """Asynchronously run all servos active within the assembly.
 
         Running the assembly takes over the current event loop and schedules a `ServoRunner` instance for each servo active in the assembly.
@@ -338,8 +354,9 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
                 [task.cancel() for task in tasks]
 
                 # Restart a fresh main loop
-                runner = self._runner_for_servo(servo.current_servo())
-                runner.run_main_loop()
+                if poll:
+                    runner = self._runner_for_servo(servo.current_servo())
+                    runner.run_main_loop()
             else:
                 self.logger.error(
                     f"unrecognized exception passed to progress exception handler: {error}"
@@ -354,8 +371,8 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
 
         try:
             for servo_ in self.assembly.servos:
-                servo_runner = ServoRunner(servo_)
-                loop.create_task(servo_runner.run())
+                servo_runner = ServoRunner(servo_, interactive=interactive)
+                loop.create_task(servo_runner.run(poll=poll))
                 self.runners.append(servo_runner)
 
             loop.run_forever()


### PR DESCRIPTION
This PR adds two no options to the `servo run` command:

* `--interactive / -i` - Ask for confirmation before proceeding with commands.
* `--no-poll` - Disables the polling command loop after starting the Assembly.