### PR TITLE
Increase timeout of occasionally failing CI test

### DIFF
--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1065,7 +1065,7 @@ class TestKubernetesConnectorIntegration:
         namespace,
         kube
     ) -> None:
-        tuning_config.timeout = "5s"
+        tuning_config.timeout = "10s"
         tuning_config.on_failure = FailureMode.destroy
         tuning_config.deployments[0].containers[0].memory = Memory(min="128MiB", max="128GiB", step="32MiB")
         connector = KubernetesConnector(config=tuning_config)


### PR DESCRIPTION
- increase timeout config of test_adjust_tuning_insufficient_resources
 from 5 seconds to 10