### PR TITLE
Implement correct rejection reasons (Fixes SOL-344, SOL-349)

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -910,11 +910,28 @@ class Pod(KubernetesModel):
         if not status.conditions:
             raise RuntimeError(f'Pod is not running: {self.name}')
 
+        restarted_container_statuses = list(filter(lambda cont_stat: cont_stat.restart_count > 0, (status.container_statuses or [])))
+        if restarted_container_statuses:
+            container_messages = list(map(lambda cont_stat: f"{cont_stat.name} x{cont_stat.restart_count}", restarted_container_statuses))
+            raise servo.AdjustmentRejectedError(
+                f"Tuning optimization {self.name} crash restart detected on container(s): {', '.join(container_messages)}",
+                reason="unstable"
+            )
+
         self.logger.trace(f"checking status conditions {status.conditions}")
         for cond in status.conditions:
-            if cond.reason in {"Unschedulable", "ContainersNotReady"}:
+            if cond.reason == "Unschedulable":
                 # FIXME: The servo rejected error should be raised further out. This should be a generic scheduling error
-                raise servo.AdjustmentRejectedError(message=cond.message, reason="scheduling-failed")
+                raise servo.AdjustmentRejectedError(
+                    message=cond.message,
+                    reason="unschedulable"
+                )
+
+            if cond.type == "Ready" and cond.status == "False":
+                raise servo.AdjustmentRejectedError(
+                    message=f"(reason {cond.reason}) {cond.message}",
+                    reason="start-failed"
+                )
 
             # we only care about the condition type 'ready'
             if cond.type.lower() != "ready":
@@ -1786,7 +1803,7 @@ class Deployment(KubernetesModel):
                     if event_type == "ERROR":
                         stream.stop()
                         # FIXME: Not sure what types we expect here
-                        raise servo.AdjustmentRejectedError(reason=str(deployment))
+                        raise servo.AdjustmentRejectedError(str(deployment))
 
                     # Check that the conditions aren't reporting a failure
                     if status.conditions:
@@ -1845,8 +1862,7 @@ class Deployment(KubernetesModel):
                 # TODO: Check what this error looks like
                 raise servo.AdjustmentRejectedError(
                     "ReplicaFailure: message='{condition.status.message}', reason='{condition.status.reason}'",
-                    condition.status.message,
-                    reason=condition.status.reason
+                    reason="start-failed"
                 )
 
             elif condition.type == "Progressing":
@@ -1857,8 +1873,7 @@ class Deployment(KubernetesModel):
                 elif condition.status == "False":
                     raise servo.AdjustmentRejectedError(
                         "ProgressionFailure: message='{condition.status.message}', reason='{condition.status.reason}'",
-                        condition.status.message,
-                        reason=condition.status.reason
+                        reason="start-failed"
                     )
                 else:
                     raise servo.AdjustmentFailedError(
@@ -1901,7 +1916,7 @@ class Deployment(KubernetesModel):
             fmt_str = ", ".join(pod_fmts)
             raise servo.AdjustmentRejectedError(
                 message=f"{len(unschedulable_pods)} pod(s) could not be scheduled for deployment {self.name}: {fmt_str}",
-                reason="scheduling-failed"
+                reason="unschedulable"
             )
 
         restarted_pods_container_statuses = [
@@ -3125,29 +3140,34 @@ class KubernetesOptimizations(pydantic.BaseModel, servo.logging.Mixin):
                 f"waiting for adjustments to take effect on {len(self.optimizations)} optimizations"
             )
             try:
-                results = await asyncio.wait_for(
-                    asyncio.gather(
-                        *list(map(lambda a: a.apply(), self.optimizations)),
-                        return_exceptions=True,
-                    ),
-                    timeout=timeout.total_seconds() + 60, # allow sub-optimization timeouts to expire first
+                gather_apply = asyncio.gather(
+                    *list(map(lambda a: a.apply(), self.optimizations)),
+                    return_exceptions=True,
                 )
-
-                for result in results:
-                    if isinstance(result, Exception):
-                        for optimization in self.optimizations:
-                            if await optimization.handle_error(result):
-                                # Stop error propagation once it has been handled
-                                break
+                results = await asyncio.wait_for(gather_apply, timeout=timeout.total_seconds() + 60) # allow sub-optimization timeouts to expire first
 
             except asyncio.exceptions.TimeoutError as error:
                 self.logger.error(
                     f"timed out after {timeout} + 60s waiting for adjustments to apply"
                 )
+                # Prevent "_GatheringFuture exception was never retrieved" warning if the above wait_for raises a timeout error
+                # https://bugs.python.org/issue29432
+                try:
+                    await gather_apply
+                except asyncio.CancelledError:
+                    pass
                 for optimization in self.optimizations:
                     if await optimization.handle_error(error):
                         # Stop error propagation once it has been handled
                         break
+                raise  # No results to process in this case, reraise timeout if handlers didn't
+
+            for result in results:
+                if isinstance(result, Exception):
+                    for optimization in self.optimizations:
+                        if await optimization.handle_error(result):
+                            # Stop error propagation once it has been handled
+                            break
         else:
             self.logger.warning(f"failed to apply adjustments: no adjustables")
 
@@ -3685,8 +3705,10 @@ class KubernetesConnector(servo.BaseConnector):
                 readiness_monitor()
             )
             if not await state.is_ready():
+                self.logger.warning("Rejection triggered without running error handler")
                 raise servo.AdjustmentRejectedError(
-                    reason="Optimization target became unready after adjustment settlement period"
+                    "Optimization target became unready after adjustment settlement period (WARNING: error handler was not run)",
+                    reason="unstable"
                 )
             self.logger.info(
                 f"Settlement duration of {settlement} has elapsed, resuming optimization."

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -928,16 +928,10 @@ class Pod(KubernetesModel):
         for cond in status.conditions:
             if cond.reason == "Unschedulable":
                 # FIXME: The servo rejected error should be raised further out. This should be a generic scheduling error
-                raise servo.AdjustmentRejectedError(
-                    message=cond.message,
-                    reason="unschedulable"
-                )
+                raise servo.AdjustmentRejectedError(cond.message, reason="unschedulable")
 
             if cond.type == "Ready" and cond.status == "False":
-                raise servo.AdjustmentRejectedError(
-                    message=f"(reason {cond.reason}) {cond.message}",
-                    reason="start-failed"
-                )
+                raise servo.AdjustmentRejectedError(f"(reason {cond.reason}) {cond.message}", reason="start-failed")
 
             # we only care about the condition type 'ready'
             if cond.type.lower() != "ready":
@@ -1809,7 +1803,7 @@ class Deployment(KubernetesModel):
                     if event_type == "ERROR":
                         stream.stop()
                         # FIXME: Not sure what types we expect here
-                        raise servo.AdjustmentRejectedError(str(deployment))
+                        raise servo.AdjustmentRejectedError(str(deployment), reason="start-failed")
 
                     # Check that the conditions aren't reporting a failure
                     if status.conditions:
@@ -1867,7 +1861,7 @@ class Deployment(KubernetesModel):
             elif condition.type == "ReplicaFailure":
                 # TODO: Check what this error looks like
                 raise servo.AdjustmentRejectedError(
-                    "ReplicaFailure: message='{condition.status.message}', reason='{condition.status.reason}'",
+                    f"ReplicaFailure: message='{condition.status.message}', reason='{condition.status.reason}'",
                     reason="start-failed"
                 )
 
@@ -1878,7 +1872,7 @@ class Deployment(KubernetesModel):
                     break
                 elif condition.status == "False":
                     raise servo.AdjustmentRejectedError(
-                        "ProgressionFailure: message='{condition.status.message}', reason='{condition.status.reason}'",
+                        f"ProgressionFailure: message='{condition.status.message}', reason='{condition.status.reason}'",
                         reason="start-failed"
                     )
                 else:
@@ -1921,7 +1915,7 @@ class Deployment(KubernetesModel):
 
             fmt_str = ", ".join(pod_fmts)
             raise servo.AdjustmentRejectedError(
-                message=f"{len(unschedulable_pods)} pod(s) could not be scheduled for deployment {self.name}: {fmt_str}",
+                f"{len(unschedulable_pods)} pod(s) could not be scheduled for deployment {self.name}: {fmt_str}",
                 reason="unschedulable"
             )
 
@@ -1967,7 +1961,7 @@ class Deployment(KubernetesModel):
                 unready_pod_conds
             ))
             raise servo.AdjustmentRejectedError(
-                message=f"Found {len(unready_pod_conds)} unready pod(s) for deployment {self.name}: {pod_message}",
+                f"Found {len(unready_pod_conds)} unready pod(s) for deployment {self.name}: {pod_message}",
                 reason="start-failed"
             )
 

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1345,7 +1345,7 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
             raise e from rejection_info.value
 
     async def test_adjust_deployment_oom_killed(self, config: KubernetesConfiguration, kubetest_deployemnt_oom_killed: KubetestDeployment) -> None:
-        config.timeout = "5s"
+        config.timeout = "10s"
         connector = KubernetesConnector(config=config)
 
         adjustment = Adjustment(

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1031,8 +1031,14 @@ class TestKubernetesConnectorIntegration:
             setting_name="mem",
             value="128Gi",
         )
-        with pytest.raises(AdjustmentRejectedError, match='Insufficient memory.'):
+        with pytest.raises(AdjustmentRejectedError, match='Insufficient memory.') as rejection_info:
             await connector.adjust([adjustment])
+
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert rejection_info.value.reason == "unschedulable"
+        except AssertionError as e:
+            raise e from rejection_info.value
 
     async def test_adjust_replicas(self, config):
         connector = KubernetesConnector(config=config)
@@ -1082,6 +1088,12 @@ class TestKubernetesConnectorIntegration:
         )
         with pytest.raises(AdjustmentRejectedError, match="Insufficient memory.") as rejection_info:
             await connector.adjust([adjustment])
+
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert rejection_info.value.reason == "unschedulable"
+        except AssertionError as e:
+            raise e from rejection_info.value
 
 
     async def test_bad_request_error_handled_gracefully(self, tuning_config: KubernetesConfiguration, mocker: pytest_mock.MockerFixture) -> None:
@@ -1140,11 +1152,9 @@ class TestKubernetesConnectorIntegration:
             setting_name="mem",
             value="128Gi",
         )
-        with pytest.raises(AdjustmentRejectedError) as rejection_info:
+        with pytest.raises(AdjustmentRejectedError, match="Insufficient memory.") as rejection_info:
             description = await connector.adjust([adjustment])
             debug(description)
-
-        assert "Insufficient memory." in str(rejection_info.value)
 
         await Deployment.read("fiber-http", kube.namespace)
 
@@ -1281,6 +1291,22 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
         return kubetest_deployment
 
     @pytest.fixture
+    def kubetest_deployemnt_oom_killed(self, kubetest_deployment: KubetestDeployment) -> KubetestDeployment:
+        fiber_container = kubetest_deployment.obj.spec.template.spec.containers[0]
+        fiber_container.command = [ "/bin/sh" ]
+        # Simulate a deployment which will be OOMKilled when memory adjusted to < 192Mi
+        fiber_container.args = [ "-c", (
+            "if [ $(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) -gt 201326592 ]; "
+                "then /bin/fiber-http; "
+                "else tail /dev/zero; "
+            "fi"
+        )]
+
+        kubetest_deployment.create()
+        kubetest_deployment.wait_until_ready(timeout=30)
+        return kubetest_deployment
+
+    @pytest.fixture
     def kubetest_deployment_becomes_unready(self, kubetest_deployment: KubetestDeployment) -> KubetestDeployment:
         fiber_container = kubetest_deployment.obj.spec.template.spec.containers[0]
         fiber_container.command = [ "/bin/sh" ]
@@ -1311,8 +1337,32 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
         with pytest.raises(AdjustmentRejectedError) as rejection_info:
             await connector.adjust([adjustment])
 
-        assert "(reason ContainersNotReady) containers with unready status: [fiber-http]" in str(rejection_info.value)
-        assert rejection_info.value.reason == "start-failed"
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert "(reason ContainersNotReady) containers with unready status: [fiber-http" in str(rejection_info.value)
+            assert rejection_info.value.reason == "start-failed"
+        except AssertionError as e:
+            raise e from rejection_info.value
+
+    async def test_adjust_deployment_oom_killed(self, config: KubernetesConfiguration, kubetest_deployemnt_oom_killed: KubetestDeployment) -> None:
+        config.timeout = "5s"
+        connector = KubernetesConnector(config=config)
+
+        adjustment = Adjustment(
+            component_name="fiber-http/fiber-http",
+            setting_name="mem",
+            value="128Mi",
+        )
+
+        with pytest.raises(AdjustmentRejectedError) as rejection_info:
+            await connector.adjust([adjustment])
+
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert "Deployment fiber-http pod(s) crash restart detected: fiber-http-" in str(rejection_info.value)
+            assert rejection_info.value.reason == "unstable"
+        except AssertionError as e:
+            raise e from rejection_info.value
 
     async def test_adjust_deployment_settlement_failed(
         self,
@@ -1332,17 +1382,87 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
         with pytest.raises(AdjustmentRejectedError) as rejection_info:
             await connector.adjust([adjustment])
 
-        assert (
-            "(reason ContainersNotReady) containers with unready status: [fiber-http]" in str(rejection_info.value)
-            or "Deployment fiber-http pod(s) crash restart detected" in str(rejection_info.value)
-        ), str(rejection_info.value)
-        assert rejection_info.value.reason == "unstable"
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert (
+                "(reason ContainersNotReady) containers with unready status: [fiber-http]" in str(rejection_info.value)
+                or "Deployment fiber-http pod(s) crash restart detected" in str(rejection_info.value)
+            ), str(rejection_info.value)
+            assert rejection_info.value.reason == "unstable"
+        except AssertionError as e:
+            raise e from rejection_info.value
 
         # Validate deployment destroyed
         with pytest.raises(kubernetes.client.exceptions.ApiException) as not_found_error:
             kubetest_deployment_becomes_unready.refresh()
 
         assert not_found_error.value.status == 404 and not_found_error.value.reason == "Not Found", str(not_found_error.value)
+
+    async def test_adjust_tuning_never_ready(
+        self,
+        tuning_config: KubernetesConfiguration,
+        kubetest_deployment_never_ready: KubetestDeployment,
+        kube: kubetest.client.TestClient
+    ) -> None:
+        tuning_config.timeout = "25s"
+        tuning_config.on_failure = FailureMode.destroy
+        tuning_config.deployments[0].on_failure = FailureMode.destroy
+        connector = KubernetesConnector(config=tuning_config)
+
+        adjustment = Adjustment(
+            component_name="fiber-http/fiber-http-tuning",
+            setting_name="mem",
+            value="128Mi",
+        )
+
+        with pytest.raises(AdjustmentRejectedError) as rejection_info:
+            await connector.adjust([adjustment])
+
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert "(reason ContainersNotReady) containers with unready status: [fiber-http" in str(rejection_info.value)
+            assert rejection_info.value.reason == "start-failed"
+        except AssertionError as e:
+            raise e from rejection_info.value
+
+        # Validate baseline was restored during handle_error
+        tuning_pod = kube.get_pods()["fiber-http-tuning"]
+        fiber_container = next(filter(lambda cont: cont.name == "fiber-http", tuning_pod.obj.spec.containers))
+        assert fiber_container.resources.requests["memory"] == "256Mi"
+        assert fiber_container.resources.limits["memory"] == "256Mi"
+
+    async def test_adjust_tuning_oom_killed(
+        self,
+        tuning_config: KubernetesConfiguration,
+        kubetest_deployemnt_oom_killed: KubetestDeployment,
+        kube: kubetest.client.TestClient
+    ) -> None:
+        tuning_config.timeout = "25s"
+        tuning_config.on_failure = FailureMode.destroy
+        tuning_config.deployments[0].on_failure = FailureMode.destroy
+        connector = KubernetesConnector(config=tuning_config)
+
+        adjustment = Adjustment(
+            component_name="fiber-http/fiber-http-tuning",
+            setting_name="mem",
+            value="128Mi",
+        )
+
+        with pytest.raises(AdjustmentRejectedError) as rejection_info:
+            await connector.adjust([adjustment])
+
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert "Tuning optimization fiber-http-tuning crash restart detected on container(s): fiber-http" in str(rejection_info.value)
+            assert rejection_info.value.reason == "unstable"
+        except AssertionError as e:
+            raise e from rejection_info.value
+
+        # Validate baseline was restored during handle_error
+        tuning_pod = kube.get_pods()["fiber-http-tuning"]
+        fiber_container = next(filter(lambda cont: cont.name == "fiber-http", tuning_pod.obj.spec.containers))
+        assert fiber_container.resources.requests["memory"] == "256Mi"
+        assert fiber_container.resources.limits["memory"] == "256Mi"
 
     async def test_adjust_tuning_settlement_failed(
         self,
@@ -1369,12 +1489,15 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
         # Validate no warnings were raised to ensure all coroutines were awaited
         assert len(recwarn) == 0, list(map(lambda warn: warn.message, recwarn))
 
-        # Validate the correct error was raised
-        assert str(rejection_info.value) == "containers with unready status: [fiber-http]", traceback.format_exception(
-            type(rejection_info.value),
-            rejection_info.value,
-            rejection_info.value.__traceback__
-        )
+        # Validate the correct error was raised, re-raise if not for additional debugging context
+        try:
+            assert (
+                "(reason ContainersNotReady) containers with unready status: [fiber-http]" in str(rejection_info.value)
+                or "Tuning optimization fiber-http-tuning crash restart detected on container(s): fiber-http" in str(rejection_info.value)
+            )
+            rejection_info.value.reason == "unstable"
+        except AssertionError as e:
+            raise e from rejection_info.value
 
         # Validate baseline was restored during handle_error
         tuning_pod = kube.get_pods()["fiber-http-tuning"]


### PR DESCRIPTION
- Add tuning optimization check for restarted containers
- Update scheduling-failed reasons to unschedulable
- Don't treat start-failed as unschedulable
- update event_type == ERROR to use message instead of reason
- Update ReplicaFailure, Progressing.status == False to correct reason
- Move handle_error out of apply timeout error handling to prevent
 redundant invokation
- wait for gather awaitable cancellation on timeout to prevent
 exception never retrieved warning
- Set correct message, reason on final settlement check, add warning that
 handle_error was not run for it
- Refactor tests to provide context on the error if it fails assertions
- Add tests for OOMKilled on adjustment
- Add test for tuning optimization start-failed