### PR TITLE
Add onboarding to check for VPA

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -3636,6 +3636,45 @@ class KubernetesChecks(servo.BaseChecks):
 
         return self.config.deployments, check_deployment
 
+    @servo.multicheck('Deployment "{item.name}" is not managed by a vertical pod autoscaler')
+    async def check_deployments_for_vpa(self) -> Tuple[Iterable, servo.CheckHandler]:
+        async def check_deployment_vpa(dep_config: DeploymentConfiguration) -> None:
+            async with kubernetes_asyncio.client.api_client.ApiClient() as api:
+                # Determine stored version(s) of VPA
+                api_extensions_client = kubernetes_asyncio.client.ApiextensionsV1Api(api)
+                try:
+                    with servo.logger.catch(level="WARNING", reraise=True, message="Unable to read Vertical Pod Autoscaler CRD"):
+                        vpa_crd = await api_extensions_client.read_custom_resource_definition(name="verticalpodautoscalers.autoscaling.k8s.io")
+                except Exception:
+                    # VPA likely not present or we don't have permission to check for it. error was logged
+                    return
+
+                # List VPAs for each stored version
+                vpas_to_check = []
+                custom_objects_client = kubernetes_asyncio.client.CustomObjectsApi(api)
+                for version in vpa_crd.status.stored_versions:
+                    vpas_for_ver = await custom_objects_client.list_namespaced_custom_object(
+                        group="autoscaling.k8s.io",
+                        version=version,
+                        namespace=dep_config.namespace,
+                        plural="verticalpodautoscalers"
+                    )
+                    vpas_to_check.extend(vpas_for_ver['items'])
+
+                vpas_for_deployment = list(filter(
+                    lambda vpa: (
+                        vpa['spec']['targetRef']['kind'] == "Deployment" 
+                        and vpa['spec']['targetRef']['name'] == dep_config.name
+                    ), 
+                    vpas_to_check
+                ))
+                if vpas_for_deployment:
+                    # Should only be 1 VPA per dep in sane setups but you never know
+                    vpa_name = ", ".join(list(map(lambda vpa: vpa["metadata"]["name"], vpas_for_deployment)))
+                    raise RuntimeError(f'Deployment "{dep_config.name}" is managed by VPA "{vpa_name}"')
+
+        return self.config.deployments, check_deployment_vpa
+
 
 @servo.metadata(
     description="Kubernetes adjust connector",

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -3663,9 +3663,9 @@ class KubernetesChecks(servo.BaseChecks):
 
                 vpas_for_deployment = list(filter(
                     lambda vpa: (
-                        vpa['spec']['targetRef']['kind'] == "Deployment" 
+                        vpa['spec']['targetRef']['kind'] == "Deployment"
                         and vpa['spec']['targetRef']['name'] == dep_config.name
-                    ), 
+                    ),
                     vpas_to_check
                 ))
                 if vpas_for_deployment:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -194,6 +194,7 @@ class Subprocess:
             timeout=timeout,
             stdout_callback=create_output_callback("stdout", stdout),
             stderr_callback=create_output_callback("stderr", stderr),
+            **kwargs,
         )
         return SubprocessResult(return_code, stdout, stderr)
 

--- a/tests/kubernetes_test.py
+++ b/tests/kubernetes_test.py
@@ -364,6 +364,15 @@ class TestChecks:
         assert result.id, "check_resource_requirements_item_0"
         assert not result.success, f"Checking resource requirements \"{config.deployments[0].name}\" in namespace \"{config.namespace}\" failed: {result.exception or result.message or result}"
 
+    async def test_check_for_vpa_success(self, config: servo.connectors.kubernetes.KubernetesConfiguration) -> None:
+        results = await servo.connectors.kubernetes.KubernetesChecks.run(
+            config, matching=servo.checks.CheckFilter(id="check_deployments_for_vpa_item_0")
+        )
+        assert results
+        result = results[-1]
+        assert result.id == "check_deployments_for_vpa_item_0"
+        assert result.success
+
 @pytest.mark.applymanifests("manifests", files=["fiber-http.yaml"])
 class TestService:
     @pytest.fixture(autouse=True)

--- a/tests/system/autoscaler_test.py
+++ b/tests/system/autoscaler_test.py
@@ -1,0 +1,100 @@
+from tests.connectors.kubernetes_test import namespace
+import loguru
+import pytest
+
+from typing import Iterator, Optional
+
+import servo.checks
+import servo.connectors.kubernetes
+
+MINIKUBE_PROFILE_CONTEXT = "servox-minikube"
+
+pytestmark = [
+    pytest.mark.system,
+    pytest.mark.minikube_profile.with_args(MINIKUBE_PROFILE_CONTEXT)
+]
+
+# override kubetest context
+@pytest.fixture
+def kubecontext() -> Optional[str]:
+    return MINIKUBE_PROFILE_CONTEXT
+
+# TODO: change to kind cluster if VPA supported
+@pytest.fixture
+async def vertical_pod_autoscaler(kubeconfig, kubecontext, minikube, subprocess) -> Iterator[None]:
+    # enable metrics server addon
+    exit_code, _, stderr = await subprocess(f"KUBECONFIG={kubeconfig} minikube addons -p {MINIKUBE_PROFILE_CONTEXT} enable metrics-server", print_output=True)
+    assert exit_code == 0, f"enable metrics server failed: {stderr}"
+
+    # clone autoscaler repo
+    exit_code, _, stderr = await subprocess("git clone https://github.com/kubernetes/autoscaler.git")
+    assert exit_code == 0, f"clone autoscaler repo failed: {stderr}"
+
+    # cache current context
+    restore_context = None
+    exit_code, stdout, stderr = await subprocess("kubectl --kubeconfig={kubeconfig} config current-context")
+    if exit_code == 0:
+        restore_context = stdout[0]
+    else:
+        loguru.logger.warning(f"get current-context failed: {stderr}")
+
+    # set current context to minikube for VPA installation
+    exit_code, _, stderr = await subprocess(f"kubectl --kubeconfig={kubeconfig} config use-context {kubecontext}")
+    assert exit_code == 0, f"set default context to minikube failed: {stderr}"
+
+    # install vertical pod autoscaler
+    exit_code, _, stderr = await subprocess(f"KUBECONFIG={kubeconfig} ./hack/vpa-up.sh", print_output=True, cwd="autoscaler/vertical-pod-autoscaler")
+    assert exit_code == 0, f"set default context to minikube failed: {stderr}"
+
+    yield
+
+    # restore previous context
+    if restore_context:
+        exit_code, stdout, stderr = await subprocess(f"kubectl --kubeconfig={kubeconfig} config use-context {restore_context}")
+        assert exit_code == 0, f"restoring default context previous value failed: {stderr}"
+
+async def test_check_for_vpa_failure(vertical_pod_autoscaler, kubernetes_asyncio_config, kubeconfig, kubecontext, kube, subprocess) -> None:
+    # NOTE: have to use subprocess as kubetest client does not recognize VPA objects
+    exit_code, _, stderr = await subprocess(
+        f"kubectl --kubeconfig={kubeconfig} --context={kubecontext} apply -n {kube.namespace} -f autoscaler/vertical-pod-autoscaler/examples/hamster.yaml",
+        print_output=True
+    )
+    assert exit_code == 0, f"apply VPA example deployment failed: {stderr}"
+
+    exit_code, _, stderr = await subprocess(
+        f"kubectl --kubeconfig={kubeconfig} --context={kubecontext} wait --for=condition=available --timeout=60s -n {kube.namespace} deployment hamster",
+        print_output=True
+    )
+    assert exit_code == 0, f"wait for VPA example deployment failed: {stderr}"
+
+
+    checks = servo.connectors.kubernetes.KubernetesChecks(
+        servo.connectors.kubernetes.KubernetesConfiguration(
+            namespace=kube.namespace,
+            deployments=[
+                servo.connectors.kubernetes.DeploymentConfiguration(
+                    name="hamster",
+                    replicas=servo.Replicas(
+                        min=1,
+                        max=4,
+                    ),
+                    containers=[
+                        servo.connectors.kubernetes.ContainerConfiguration(
+                            name="hamster",
+                            cpu=servo.connectors.kubernetes.CPU(min="100m", max="500m", step="100m"),
+                            memory=servo.connectors.kubernetes.Memory(min="50MiB", max="500MiB", step="50MiB"),
+                        )
+                    ],
+                )
+            ],
+        )
+    )
+    results = await checks.run_all(
+        matching=servo.checks.CheckFilter(id=["check_deployments_for_vpa_item_0"])
+    )
+    assert len(results)
+    result = results[-1]
+    assert result.id == "check_deployments_for_vpa_item_0"
+    assert not result.success
+    assert result.exception
+    assert str(result.exception) == 'Deployment "hamster" is managed by VPA "hamster-vpa"'

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -16,7 +16,7 @@ async def servo_image(request) -> str:
     return image
 
 @pytest.fixture
-async def minikube(request, subprocess) -> str:
+async def minikube(request, subprocess, kubeconfig: str) -> str:
     """Run tests within a local minikube profile.
 
     The profile name is determined using the parametrized `minikube_profile` marker
@@ -30,7 +30,7 @@ async def minikube(request, subprocess) -> str:
         profile = "servox"
 
     # Start minikube and configure environment
-    exit_code, _, _ = await subprocess(f"minikube start -p {profile} --interactive=false --keep-context=true --wait=true", print_output=True)
+    exit_code, _, _ = await subprocess(f"KUBECONFIG={kubeconfig} minikube start -p {profile} --interactive=false --keep-context=true --wait=true", print_output=True,)
     if exit_code != 0:
         raise RuntimeError(f"failed running minikube: exited with status code {exit_code}")
 
@@ -39,7 +39,7 @@ async def minikube(request, subprocess) -> str:
         yield profile
 
     finally:
-        exit_code, _, _ = await subprocess(f"minikube stop -p {profile}", print_output=True)
+        exit_code, _, _ = await subprocess(f"KUBECONFIG={kubeconfig} minikube stop -p {profile}", print_output=True)
         if exit_code != 0:
             raise RuntimeError(f"failed running minikube: exited with status code {exit_code}")
 


### PR DESCRIPTION
- Add check for Vertical Pod Autoscaler
- Add system/integration tests for VPA check success/failure
- Update subprocess helper to pass in kwargs
- Update minikube test fixture to use test kubeconfig
- Update test_run_servo_on_kind to validate against `kubectl logs` output (Fixes ENG-28)