### PR TITLE
Fred/eng 60 servox continuous integration test suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,10 +47,10 @@ jobs:
         uses: actions/cache@v2
         id: cached-poetry
         with:
-          path: |
-            ~/.local/share/pypoetry
-            ~/.local/bin/poetry
-          key: poetry-${{ runner.os }}-1.1.5
+          path: ~/.local/share/pypoetry
+          # NOTE: cache cannot be cleared, cN added as cache verion
+          # https://github.com/actions/cache/issues/2
+          key: poetry-${{ runner.os }}-1.1.5-c1
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.6
         if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -58,6 +58,11 @@ jobs:
           version: 1.1.5
           virtualenvs-create: true
           virtualenvs-in-project: true
+      # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
+      # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
+      - name: Symlink poetry bin
+        run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
+        if: steps.cached-poetry.outputs.cache-hit == 'true'
       - name: Source Poetry env
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -102,10 +107,10 @@ jobs:
       uses: actions/cache@v2
       id: cached-poetry
       with:
-        path: |
-          ~/.local/share/pypoetry
-          ~/.local/bin/poetry
-        key: poetry-${{ runner.os }}-1.1.5
+        path: ~/.local/share/pypoetry
+        # NOTE: cache cannot be cleared, cN added as cache verion
+        # https://github.com/actions/cache/issues/2
+        key: poetry-${{ runner.os }}-1.1.5-c1
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
       if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -113,6 +118,11 @@ jobs:
         version: 1.1.5
         virtualenvs-create: true
         virtualenvs-in-project: true
+    # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
+    # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
+    - name: Symlink poetry bin
+      run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
+      if: steps.cached-poetry.outputs.cache-hit == 'true'
     - name: Source Poetry env
       run: |
         echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -168,10 +178,10 @@ jobs:
       uses: actions/cache@v2
       id: cached-poetry
       with:
-        path: |
-          ~/.local/share/pypoetry
-          ~/.local/bin/poetry
-        key: poetry-${{ runner.os }}-1.1.5
+        path: ~/.local/share/pypoetry
+        # NOTE: cache cannot be cleared, cN added as cache verion
+        # https://github.com/actions/cache/issues/2
+        key: poetry-${{ runner.os }}-1.1.5-c1
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
       if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -179,6 +189,11 @@ jobs:
         version: 1.1.5
         virtualenvs-create: true
         virtualenvs-in-project: true
+    # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
+    # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
+    - name: Symlink poetry bin
+      run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
+      if: steps.cached-poetry.outputs.cache-hit == 'true'
     - name: Source Poetry env
       run: |
         echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -250,10 +265,10 @@ jobs:
       uses: actions/cache@v2
       id: cached-poetry
       with:
-        path: |
-          ~/.local/share/pypoetry
-          ~/.local/bin/poetry
-        key: poetry-${{ runner.os }}-1.1.5
+        path: ~/.local/share/pypoetry
+        # NOTE: cache cannot be cleared, cN added as cache verion
+        # https://github.com/actions/cache/issues/2
+        key: poetry-${{ runner.os }}-1.1.5-c1
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
       if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -261,6 +276,11 @@ jobs:
         version: 1.1.5
         virtualenvs-create: true
         virtualenvs-in-project: true
+    # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
+    # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
+    - name: Symlink poetry bin
+      run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
+      if: steps.cached-poetry.outputs.cache-hit == 'true'
     - name: Source Poetry env
       run: |
         echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,29 +43,27 @@ jobs:
         with:
           python-version: '3.8'
           architecture: x64
-      - name: Set up Poetry cache
-        uses: actions/cache@v2
-        id: cached-poetry
-        with:
-          path: ~/.local/share/pypoetry
-          # NOTE: cache cannot be cleared, cN added as cache verion
-          # https://github.com/actions/cache/issues/2
-          key: poetry-${{ runner.os }}-1.1.5-c2
+      # TODO: uncomment when POETRY_HOME supported by snok/install-poetry
+      # - name: Set up Poetry cache
+      #   uses: actions/cache@v2
+      #   id: cached-poetry
+      #   with:
+      #     path: ~/.poetry
+      #     # NOTE: cache cannot be cleared, cN added as cache verion
+      #     # https://github.com/actions/cache/issues/2
+      #     key: poetry-${{ runner.os }}-1.1.5-c3
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.6
-        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry.outputs.cache-hit != 'true'
         with:
           version: 1.1.5
           virtualenvs-create: true
           virtualenvs-in-project: true
-      # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
-      # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
-      - name: Symlink poetry bin
-        run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
-        if: steps.cached-poetry.outputs.cache-hit == 'true'
       - name: Source Poetry env
+        # TODO: apply following updates when POETRY_HOME supported by snok/install-poetry
+        # echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+        # export PATH="$HOME/.poetry/bin:$PATH"
         run: |
-          realpath ~/.local/bin/poetry
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           export PATH="$HOME/.local/bin:$PATH"
           poetry config virtualenvs.create true
@@ -104,26 +102,22 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
-    - name: Set up Poetry cache
-      uses: actions/cache@v2
-      id: cached-poetry
-      with:
-        path: ~/.local/share/pypoetry
-        # NOTE: cache cannot be cleared, cN added as cache verion
-        # https://github.com/actions/cache/issues/2
-        key: poetry-${{ runner.os }}-1.1.5-c1
+      # TODO: uncomment when POETRY_HOME supported by snok/install-poetry
+      # - name: Set up Poetry cache
+      #   uses: actions/cache@v2
+      #   id: cached-poetry
+      #   with:
+      #     path: ~/.poetry
+      #     # NOTE: cache cannot be cleared, cN added as cache verion
+      #     # https://github.com/actions/cache/issues/2
+      #     key: poetry-${{ runner.os }}-1.1.5-c3
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
-      if: steps.cached-poetry.outputs.cache-hit != 'true'
+      # if: steps.cached-poetry.outputs.cache-hit != 'true'
       with:
         version: 1.1.5
         virtualenvs-create: true
         virtualenvs-in-project: true
-    # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
-    # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
-    - name: Symlink poetry bin
-      run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
-      if: steps.cached-poetry.outputs.cache-hit == 'true'
     - name: Source Poetry env
       run: |
         echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -175,26 +169,22 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
-    - name: Set up Poetry cache
-      uses: actions/cache@v2
-      id: cached-poetry
-      with:
-        path: ~/.local/share/pypoetry
-        # NOTE: cache cannot be cleared, cN added as cache verion
-        # https://github.com/actions/cache/issues/2
-        key: poetry-${{ runner.os }}-1.1.5-c1
+      # TODO: uncomment when POETRY_HOME supported by snok/install-poetry
+      # - name: Set up Poetry cache
+      #   uses: actions/cache@v2
+      #   id: cached-poetry
+      #   with:
+      #     path: ~/.poetry
+      #     # NOTE: cache cannot be cleared, cN added as cache verion
+      #     # https://github.com/actions/cache/issues/2
+      #     key: poetry-${{ runner.os }}-1.1.5-c3
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
-      if: steps.cached-poetry.outputs.cache-hit != 'true'
+      # if: steps.cached-poetry.outputs.cache-hit != 'true'
       with:
         version: 1.1.5
         virtualenvs-create: true
         virtualenvs-in-project: true
-    # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
-    # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
-    - name: Symlink poetry bin
-      run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
-      if: steps.cached-poetry.outputs.cache-hit == 'true'
     - name: Source Poetry env
       run: |
         echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -262,26 +252,22 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
-    - name: Set up Poetry cache
-      uses: actions/cache@v2
-      id: cached-poetry
-      with:
-        path: ~/.local/share/pypoetry
-        # NOTE: cache cannot be cleared, cN added as cache verion
-        # https://github.com/actions/cache/issues/2
-        key: poetry-${{ runner.os }}-1.1.5-c1
+      # TODO: uncomment when POETRY_HOME supported by snok/install-poetry
+      # - name: Set up Poetry cache
+      #   uses: actions/cache@v2
+      #   id: cached-poetry
+      #   with:
+      #     path: ~/.poetry
+      #     # NOTE: cache cannot be cleared, cN added as cache verion
+      #     # https://github.com/actions/cache/issues/2
+      #     key: poetry-${{ runner.os }}-1.1.5-c3
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
-      if: steps.cached-poetry.outputs.cache-hit != 'true'
+      # if: steps.cached-poetry.outputs.cache-hit != 'true'
       with:
         version: 1.1.5
         virtualenvs-create: true
         virtualenvs-in-project: true
-    # NOTE: cache wasn't working with multiple files so have to reproduce some of the poetry setup
-    # https://github.com/python-poetry/poetry/blob/22c3aaddc20ad74d3633738093f685fd6dbb998a/install-poetry.py#L532-L561
-    - name: Symlink poetry bin
-      run: ln -s ~/.local/share/pypoetry/venv/bin/poetry ~/.local/bin/poetry
-      if: steps.cached-poetry.outputs.cache-hit == 'true'
     - name: Source Poetry env
       run: |
         echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,9 @@ jobs:
         uses: actions/cache@v2
         id: cached-poetry
         with:
-          path: ~/.poetry
+          path: |
+            ~/.local/share/pypoetry
+            ~/.local/bin/poetry
           key: poetry-${{ runner.os }}-1.1.5
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.6
@@ -58,10 +60,10 @@ jobs:
           virtualenvs-in-project: true
       - name: Source Poetry env
         run: |
-          source "$HOME"/.poetry/env
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          export PATH="$HOME/.local/bin:$PATH"
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Set up dependencies cache
         uses: actions/cache@v2
         id: cached-poetry-dependencies
@@ -100,7 +102,9 @@ jobs:
       uses: actions/cache@v2
       id: cached-poetry
       with:
-        path: ~/.poetry
+        path: |
+          ~/.local/share/pypoetry
+          ~/.local/bin/poetry
         key: poetry-${{ runner.os }}-1.1.5
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
@@ -111,10 +115,10 @@ jobs:
         virtualenvs-in-project: true
     - name: Source Poetry env
       run: |
-        source "$HOME"/.poetry/env
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        export PATH="$HOME/.local/bin:$PATH"
         poetry config virtualenvs.create true
         poetry config virtualenvs.in-project true
-        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
     - name: Set up root + dependencies cache
       uses: actions/cache@v2
       id: cached-project
@@ -164,7 +168,9 @@ jobs:
       uses: actions/cache@v2
       id: cached-poetry
       with:
-        path: ~/.poetry
+        path: |
+          ~/.local/share/pypoetry
+          ~/.local/bin/poetry
         key: poetry-${{ runner.os }}-1.1.5
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
@@ -175,10 +181,10 @@ jobs:
         virtualenvs-in-project: true
     - name: Source Poetry env
       run: |
-        source "$HOME"/.poetry/env
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        export PATH="$HOME/.local/bin:$PATH"
         poetry config virtualenvs.create true
         poetry config virtualenvs.in-project true
-        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
     - name: Install Vegeta
       run: |
         wget https://github.com/tsenart/vegeta/releases/download/v12.8.4/vegeta_12.8.4_linux_amd64.tar.gz
@@ -244,7 +250,9 @@ jobs:
       uses: actions/cache@v2
       id: cached-poetry
       with:
-        path: ~/.poetry
+        path: |
+          ~/.local/share/pypoetry
+          ~/.local/bin/poetry
         key: poetry-${{ runner.os }}-1.1.5
     - name: Install and configure Poetry
       uses: snok/install-poetry@v1.1.6
@@ -255,10 +263,10 @@ jobs:
         virtualenvs-in-project: true
     - name: Source Poetry env
       run: |
-        source "$HOME"/.poetry/env
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        export PATH="$HOME/.local/bin:$PATH"
         poetry config virtualenvs.create true
         poetry config virtualenvs.in-project true
-        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
     - name: Set up root + dependencies cache
       uses: actions/cache@v2
       id: cached-project

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           path: ~/.local/share/pypoetry
           # NOTE: cache cannot be cleared, cN added as cache verion
           # https://github.com/actions/cache/issues/2
-          key: poetry-${{ runner.os }}-1.1.5-c1
+          key: poetry-${{ runner.os }}-1.1.5-c2
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.6
         if: steps.cached-poetry.outputs.cache-hit != 'true'
@@ -65,6 +65,7 @@ jobs:
         if: steps.cached-poetry.outputs.cache-hit == 'true'
       - name: Source Poetry env
         run: |
+          realpath ~/.local/bin/poetry
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           export PATH="$HOME/.local/bin:$PATH"
           poetry config virtualenvs.create true


### PR DESCRIPTION
Temporarily drop poetry caching due to .local install location

As of snok/install-poetry version 1.1.5, the poetry install location is hardcoded to be the entire ~/.local directory instead of being an isolated directory as in previous versions which is problematic for caching: https://github.com/snok/install-poetry/blob/4315377389fc195a3955c4eacf49b86ca8e73f0f/scripts/v1.2/main.sh#L42