### PR TITLE
Fix custom marker warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ filterwarnings =
     ignore: .*Using or importing the ABCs from 'collections':DeprecationWarning
     ignore: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead:DeprecationWarning
     ignore: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10:DeprecationWarning
-    error: True
+    error
 
 [coverage:report]
 precision = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,10 @@ EVENT_LOOP_POLICY_INI = (
     'The `event_loop_policy` fixture determines what event loop policy is registered '
     'at runtime and respects the value of this marker.'
 )
+MINIKUBE_PROFILE_INI = (
+    'minikube_profile: marks tests using minikube to run under the profile specified'
+    'in the first marker argument. Eg. pytest.mark.minikube_profile.with_args(MINIKUBE_PROFILE)'
+)
 
 def pytest_configure(config) -> None:
     """Register custom markers for use in the test suite."""
@@ -173,6 +177,7 @@ def pytest_configure(config) -> None:
     config.addinivalue_line("markers", INTEGRATION_INI)
     config.addinivalue_line("markers", SYSTEM_INI)
     config.addinivalue_line("markers", EVENT_LOOP_POLICY_INI)
+    config.addinivalue_line("markers", MINIKUBE_PROFILE_INI)
 
     # Add generic description for all environments
     for key, value in Environment.__members__.items():


### PR DESCRIPTION
- Add pytest ini line for minikube_profile marker
- Fix setup.cfg filterwarnings error filter so any test warnings are converted to errors