### PR TITLE
Update prom metrics to support ENG-51 renaming

### DIFF
--- a/servo/connectors/opsani_dev.py
+++ b/servo/connectors/opsani_dev.py
@@ -133,11 +133,6 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
                     query='envoy_cluster_membership_healthy{opsani_role="tuning"}',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_pod_avg_request_rate",
-                    servo.types.Unit.requests_per_second,
-                    query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role!="tuning"}[1m]))',
-                ),
-                servo.connectors.prometheus.PrometheusMetric(
                     "total_request_rate",
                     servo.types.Unit.requests_per_second,
                     query="sum(rate(envoy_cluster_upstream_rq_total[1m]))",
@@ -145,34 +140,34 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
                 servo.connectors.prometheus.PrometheusMetric(
                     "main_request_rate",
                     servo.types.Unit.requests_per_second,
-                    query='sum(rate(envoy_cluster_upstream_rq_total{opsani_role!="tuning"}[1m]))',
+                    query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role!="tuning"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
                     "tuning_request_rate",
                     servo.types.Unit.requests_per_second,
-                    query='rate(envoy_cluster_upstream_rq_total{opsani_role="tuning"}[1m])',
+                    query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role="tuning"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
                     "main_success_rate",
                     servo.types.Unit.requests_per_second,
-                    query='sum(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"2|3"}[1m]))',
+                    query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"2|3"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
                     "tuning_success_rate",
                     servo.types.Unit.requests_per_second,
-                    query='sum(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"2|3"}[1m]))',
+                    query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"2|3"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
                     "main_error_rate",
                     servo.types.Unit.requests_per_second,
-                    query='sum(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"4|5"}[1m]))',
+                    query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"4|5"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
                     "tuning_error_rate",
                     servo.types.Unit.requests_per_second,
-                    query='sum(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"4|5"}[1m]))',
+                    query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"4|5"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(

--- a/servo/connectors/opsani_dev.py
+++ b/servo/connectors/opsani_dev.py
@@ -138,34 +138,34 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
                     query="sum(rate(envoy_cluster_upstream_rq_total[1m]))",
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_request_rate",
+                    "main_request_rate_avg",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role!="tuning"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "tuning_request_rate",
+                    "tuning_request_rate_avg",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role="tuning"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_success_rate",
+                    "main_success_rate_avg",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"2|3"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "tuning_success_rate",
+                    "tuning_success_rate_avg",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"2|3"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_error_rate",
+                    "main_error_rate_avg",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"4|5"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "tuning_error_rate",
+                    "tuning_error_rate_avg",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"4|5"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero


### PR DESCRIPTION
All metrics are now averages, except explicit "total" metrics
main_pod_average metric is removed
Requires updates to template to ensure matching metric names
dev2.3 rc live-traffic template being updated to match