### PR TITLE
Changes for OKO integration [ENG-166]

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -3715,7 +3715,7 @@ class KubernetesConnector(servo.BaseConnector):
         self.telemetry.remove(f"{self.name}.platform")
 
     @servo.on_event()
-    async def describe(self) -> servo.Description:
+    async def describe(self, **kwargs) -> servo.Description:
         state = await self._create_optimizations()
         return state.to_description()
 
@@ -3725,7 +3725,7 @@ class KubernetesConnector(servo.BaseConnector):
         return state.to_components()
 
     @servo.before_event(servo.Events.measure)
-    async def before_measure(self) -> None:
+    async def before_measure(self, **kwargs) -> None:
         # Build state before a measurement to ensure all necessary setup is done
         # (e.g., Tuning Pod is up and running)
         await self._create_optimizations()

--- a/servo/connectors/prometheus.py
+++ b/servo/connectors/prometheus.py
@@ -819,7 +819,7 @@ class PrometheusConnector(servo.BaseConnector):
         )
 
     @servo.on_event()
-    def describe(self) -> servo.Description:
+    def describe(self, **kwargs) -> servo.Description:
         """Describes the current state of Metrics measured by querying Prometheus.
 
         Returns:

--- a/servo/events.py
+++ b/servo/events.py
@@ -972,7 +972,7 @@ class _DispatchEvent:
             for connector in self._connectors:
                 try:
                     results = await connector.run_event_handlers(
-                        self.event, Preposition.before
+                        self.event, Preposition.before, *self._args, return_exceptions=False, **self._kwargs
                     )
 
                 except servo.errors.EventCancelledError as error:

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -68,11 +68,11 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
         # Adopt the servo config for driving the API mixin
         return self.servo.api_client_options
 
-    async def describe(self) -> Description:
+    async def describe(self, control: Control) -> Description:
         self.logger.info("Describing...")
 
         aggregate_description = Description.construct()
-        results: List[servo.EventResult] = await self.servo.dispatch_event(servo.Events.describe)
+        results: List[servo.EventResult] = await self.servo.dispatch_event(servo.Events.describe, control=control)
         for result in results:
             description = result.value
             aggregate_description.components.extend(description.components)
@@ -127,7 +127,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
         self.logger.trace(devtools.pformat(cmd_response))
 
         if cmd_response.command == servo.api.Commands.describe:
-            description = await self.describe()
+            description = await self.describe(Control(**cmd_response.param.get("control", {})))
             self.logger.success(
                 f"Described: {len(description.components)} components, {len(description.metrics)} metrics"
             )

--- a/servo/types.py
+++ b/servo/types.py
@@ -1253,6 +1253,10 @@ class Control(BaseModel):
     semantics.
     """
 
+    environment: Optional[Dict[str, Any]] = None
+    """Optional mode control.
+    """
+
     @pydantic.root_validator(pre=True)
     def validate_past_and_delay(cls, values):
         if "past" in values:

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -8,6 +8,7 @@ import pytest
 
 import servo
 import servo.runner
+import servo.types
 import tests.fake
 from tests.fake import AbstractOptimizer
 
@@ -112,7 +113,7 @@ async def test_hello_and_describe(
     assert static_optimizer.state == tests.fake.StateMachine.States.awaiting_description
 
     # get a description from the servo
-    description = await servo_runner.describe()
+    description = await servo_runner.describe(servo.types.Control())
     param = dict(descriptor=description.__opsani_repr__(), status="ok")
     response = await servo_runner._post_event(servo.api.Events.describe, param)
     assert response.status == "ok"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,12 +41,12 @@ class MeasureConnector(BaseConnector):
         ]
 
     @on_event()
-    async def describe(self) -> Description:
+    async def describe(self, **kwargs) -> Description:
         metrics = await self.metrics()
         return Description(metrics=metrics)
 
     @before_event(Events.measure)
-    def before_measure(self) -> None:
+    def before_measure(self, **kwargs) -> None:
         pass
 
     @on_event()
@@ -75,7 +75,7 @@ class MeasureConnector(BaseConnector):
 
 class AdjustConnector(BaseConnector):
     @on_event()
-    async def describe(self) -> Description:
+    async def describe(self, **kwargs) -> Description:
         components = await self.components()
         return Description(components=components)
 

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -10,6 +10,7 @@ import servo
 import servo.events
 import servo.runner
 import servo.connectors.prometheus
+import servo.types
 import tests.fake
 import tests.helpers
 
@@ -118,7 +119,7 @@ async def test_out_of_order_operations(servo_runner: servo.runner.ServoRunner) -
     debug(response)
     assert response.command in (servo.api.Commands.describe, servo.api.Commands.sleep)
 
-    description = await servo_runner.describe()
+    description = await servo_runner.describe(servo.types.Control())
 
     param = dict(descriptor=description.__opsani_repr__(), status="ok")
     debug(param)
@@ -156,7 +157,7 @@ async def test_hello(
     )
     assert response.status == "ok"
 
-    description = await servo_runner.describe()
+    description = await servo_runner.describe(servo.types.Control())
 
     param = dict(descriptor=description.__opsani_repr__(), status="ok")
     response = await servo_runner._post_event(servo.api.Events.describe, param)

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -470,7 +470,7 @@ def test_registering_event_handler_with_missing_positional_param_fails() -> None
     assert error
     assert (
         str(error.value)
-        == """invalid event handler "adjust": missing required parameter "adjustments" in callable signature "(self) -> servo.types.Description", expected "(self, adjustments: 'List[servo.types.Adjustment]', control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None)) -> 'servo.types.Description'\""""
+        == """invalid event handler "adjust": missing required parameter "adjustments" in callable signature "(self) -> servo.types.Description", expected "(self, adjustments: 'List[servo.types.Adjustment]', control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> 'servo.types.Description'\""""
     )
 
 
@@ -484,7 +484,7 @@ def test_registering_event_handler_with_missing_keyword_param_fails() -> None:
     assert error
     assert (
         str(error.value)
-        == """invalid event handler "measure": missing required parameter "metrics" in callable signature "(self, *, control: servo.types.Control = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None)) -> servo.types.Measurement", expected "(self, *, metrics: 'List[str]' = None, control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None)) -> 'servo.types.Measurement'\""""
+        == """invalid event handler "measure": missing required parameter "metrics" in callable signature "(self, *, control: servo.types.Control = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> servo.types.Measurement", expected "(self, *, metrics: 'List[str]' = None, control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> 'servo.types.Measurement'\""""
     )
 
 


### PR DESCRIPTION
send control=Control(param['control']) when dispatching 'describe'
event, fix all existing handlers of 'describe' to have **kwargs, so they
can accept this change.

call 'before_event' handlers with the same data as on_event, fix all
existing 'before' handlers to accept this (add **kwargs to the method
signature).

add 'environment' to the types/Control() class (type =
Optional[dict[str, Any]])