### PR TITLE
Changes for OKO integration [preparation for ENG-165, ENG-166]

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -4412,7 +4412,7 @@ class KubernetesConnector(servo.BaseConnector):
         self.telemetry.remove(f"{self.name}.platform")
 
     @servo.on_event()
-    async def describe(self, **kwargs) -> servo.Description:
+    async def describe(self, control: servo.Control = servo.Control()) -> servo.Description:
         state = await self._create_optimizations()
         return state.to_description()
 
@@ -4422,7 +4422,7 @@ class KubernetesConnector(servo.BaseConnector):
         return state.to_components()
 
     @servo.before_event(servo.Events.measure)
-    async def before_measure(self, **kwargs) -> None:
+    async def before_measure(self, *, metrics: List[str] = None, control: servo.Control = servo.Control()) -> None:
         # Build state before a measurement to ensure all necessary setup is done
         # (e.g., Tuning Pod is up and running)
         await self._create_optimizations()

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -4412,7 +4412,7 @@ class KubernetesConnector(servo.BaseConnector):
         self.telemetry.remove(f"{self.name}.platform")
 
     @servo.on_event()
-    async def describe(self) -> servo.Description:
+    async def describe(self, **kwargs) -> servo.Description:
         state = await self._create_optimizations()
         return state.to_description()
 
@@ -4422,7 +4422,7 @@ class KubernetesConnector(servo.BaseConnector):
         return state.to_components()
 
     @servo.before_event(servo.Events.measure)
-    async def before_measure(self) -> None:
+    async def before_measure(self, **kwargs) -> None:
         # Build state before a measurement to ensure all necessary setup is done
         # (e.g., Tuning Pod is up and running)
         await self._create_optimizations()

--- a/servo/connectors/prometheus.py
+++ b/servo/connectors/prometheus.py
@@ -819,7 +819,7 @@ class PrometheusConnector(servo.BaseConnector):
         )
 
     @servo.on_event()
-    def describe(self, **kwargs) -> servo.Description:
+    def describe(self, control: servo.Control = servo.Control()) -> servo.Description:
         """Describes the current state of Metrics measured by querying Prometheus.
 
         Returns:

--- a/servo/connectors/prometheus.py
+++ b/servo/connectors/prometheus.py
@@ -819,7 +819,7 @@ class PrometheusConnector(servo.BaseConnector):
         )
 
     @servo.on_event()
-    def describe(self) -> servo.Description:
+    def describe(self, **kwargs) -> servo.Description:
         """Describes the current state of Metrics measured by querying Prometheus.
 
         Returns:

--- a/servo/connectors/vegeta.py
+++ b/servo/connectors/vegeta.py
@@ -303,7 +303,7 @@ class VegetaConnector(servo.BaseConnector):
     config: VegetaConfiguration
 
     @servo.on_event()
-    def describe(self) -> servo.Description:
+    def describe(self, control: servo.Control = servo.Control()) -> servo.Description:
         """
         Describes the metrics and components exported by the connector.
         """

--- a/servo/events.py
+++ b/servo/events.py
@@ -972,7 +972,7 @@ class _DispatchEvent:
             for connector in self._connectors:
                 try:
                     results = await connector.run_event_handlers(
-                        self.event, Preposition.before
+                        self.event, Preposition.before, *self._args, return_exceptions=False, **self._kwargs
                     )
 
                 except servo.errors.EventCancelledError as error:

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -68,11 +68,11 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
         # Adopt the servo config for driving the API mixin
         return self.servo.api_client_options
 
-    async def describe(self) -> Description:
+    async def describe(self, control: Control) -> Description:
         self.logger.info("Describing...")
 
         aggregate_description = Description.construct()
-        results: List[servo.EventResult] = await self.servo.dispatch_event(servo.Events.describe)
+        results: List[servo.EventResult] = await self.servo.dispatch_event(servo.Events.describe, control=control)
         for result in results:
             description = result.value
             aggregate_description.components.extend(description.components)
@@ -127,7 +127,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin, servo.api.Mixin):
         self.logger.trace(devtools.pformat(cmd_response))
 
         if cmd_response.command == servo.api.Commands.describe:
-            description = await self.describe()
+            description = await self.describe(Control(**cmd_response.param.get("control", {})))
             self.logger.success(
                 f"Described: {len(description.components)} components, {len(description.metrics)} metrics"
             )

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -117,7 +117,7 @@ class _EventDefinitions(Protocol):
         ...
 
     @servo.events.event(Events.describe)
-    async def describe(self) -> servo.types.Description:
+    async def describe(self, control: servo.types.Control = servo.types.Control()) -> servo.types.Description:
         ...
 
     @servo.events.event(Events.adjust)

--- a/servo/types.py
+++ b/servo/types.py
@@ -1253,6 +1253,10 @@ class Control(BaseModel):
     semantics.
     """
 
+    environment: Optional[Dict[str, Any]] = None
+    """Optional mode control.
+    """
+
     @pydantic.root_validator(pre=True)
     def validate_past_and_delay(cls, values):
         if "past" in values:

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1570,7 +1570,6 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
         self,
         tuning_config: KubernetesConfiguration,
         kubetest_deployment_becomes_unready: KubetestDeployment,
-        recwarn: pytest.WarningsRecorder,
         kube: kubetest.client.TestClient
     ) -> None:
         tuning_config.timeout = "25s"
@@ -1587,9 +1586,6 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
         )
         with pytest.raises(AdjustmentRejectedError) as rejection_info:
             await connector.adjust([adjustment])
-
-        # Validate raised warnings to ensure all coroutines were awaited
-        assert not any(filter(lambda warn: "was never awaited" in warn.message, recwarn)), list(map(lambda warn: warn.message, recwarn))
 
         # Validate the correct error was raised, re-raise if not for additional debugging context
         try:

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -8,6 +8,7 @@ import pytest
 
 import servo
 import servo.runner
+import servo.types
 import tests.fake
 from tests.fake import AbstractOptimizer
 
@@ -112,7 +113,7 @@ async def test_hello_and_describe(
     assert static_optimizer.state == tests.fake.StateMachine.States.awaiting_description
 
     # get a description from the servo
-    description = await servo_runner.describe()
+    description = await servo_runner.describe(servo.types.Control())
     param = dict(descriptor=description.__opsani_repr__(), status="ok")
     response = await servo_runner._post_event(servo.api.Events.describe, param)
     assert response.status == "ok"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,12 +41,12 @@ class MeasureConnector(BaseConnector):
         ]
 
     @on_event()
-    async def describe(self, **kwargs) -> Description:
+    async def describe(self, control: servo.Control = servo.Control()) -> Description:
         metrics = await self.metrics()
         return Description(metrics=metrics)
 
     @before_event(Events.measure)
-    def before_measure(self, **kwargs) -> None:
+    def before_measure(self, *, metrics: List[str] = None, control: servo.Control = servo.Control()) -> None:
         pass
 
     @on_event()
@@ -75,7 +75,7 @@ class MeasureConnector(BaseConnector):
 
 class AdjustConnector(BaseConnector):
     @on_event()
-    async def describe(self, **kwargs) -> Description:
+    async def describe(self, control: servo.Control = servo.Control()) -> Description:
         components = await self.components()
         return Description(components=components)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,12 +41,12 @@ class MeasureConnector(BaseConnector):
         ]
 
     @on_event()
-    async def describe(self) -> Description:
+    async def describe(self, **kwargs) -> Description:
         metrics = await self.metrics()
         return Description(metrics=metrics)
 
     @before_event(Events.measure)
-    def before_measure(self) -> None:
+    def before_measure(self, **kwargs) -> None:
         pass
 
     @on_event()
@@ -75,7 +75,7 @@ class MeasureConnector(BaseConnector):
 
 class AdjustConnector(BaseConnector):
     @on_event()
-    async def describe(self) -> Description:
+    async def describe(self, **kwargs) -> Description:
         components = await self.components()
         return Description(components=components)
 

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -10,6 +10,7 @@ import servo
 import servo.events
 import servo.runner
 import servo.connectors.prometheus
+import servo.types
 import tests.fake
 import tests.helpers
 
@@ -118,7 +119,7 @@ async def test_out_of_order_operations(servo_runner: servo.runner.ServoRunner) -
     debug(response)
     assert response.command in (servo.api.Commands.describe, servo.api.Commands.sleep)
 
-    description = await servo_runner.describe()
+    description = await servo_runner.describe(servo.types.Control())
 
     param = dict(descriptor=description.__opsani_repr__(), status="ok")
     debug(param)
@@ -156,7 +157,7 @@ async def test_hello(
     )
     assert response.status == "ok"
 
-    description = await servo_runner.describe()
+    description = await servo_runner.describe(servo.types.Control())
 
     param = dict(descriptor=description.__opsani_repr__(), status="ok")
     response = await servo_runner._post_event(servo.api.Events.describe, param)

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -41,7 +41,7 @@ class FirstTestServoConnector(BaseConnector):
         return "adjusting!"
 
     @before_event(Events.measure)
-    def do_something_before_measuring(self) -> None:
+    def do_something_before_measuring(self, metrics: List[str] = [], control: servox.Control = None) -> None:
         return "measuring!"
 
     @before_event(Events.promote)
@@ -524,7 +524,7 @@ def test_registering_event_handler_with_too_many_keyword_params_fails() -> None:
 
 def test_registering_before_handlers() -> None:
     @before_event("measure")
-    def before_measure(self) -> None:
+    def before_measure(self, metrics: List[str] = [], control: servox.Control = None) -> None:
         pass
 
     assert before_measure.__event_handler__.event.name == "measure"
@@ -541,7 +541,7 @@ def test_registering_before_handler_fails_with_extra_args() -> None:
     assert error
     assert (
         str(error.value)
-        == """invalid before event handler "before:measure": encountered unexpected parameters "another and invalid" in callable signature "(self, invalid: str, another: int) -> None", expected "(self) -> 'None'\""""
+        == """invalid before event handler "before:measure": encountered unexpected parameters "another and invalid" in callable signature "(self, invalid: str, another: int) -> None", expected "(self, *, metrics: 'List[str]' = None, control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> 'None'\""""
     )
 
 

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -41,7 +41,7 @@ class FirstTestServoConnector(BaseConnector):
         return "adjusting!"
 
     @before_event(Events.measure)
-    def do_something_before_measuring(self, metrics: List[str] = [], control: servox.Control = None) -> None:
+    def do_something_before_measuring(self, metrics: List[str] = [], control: Control = Control()) -> None:
         return "measuring!"
 
     @before_event(Events.promote)
@@ -524,7 +524,7 @@ def test_registering_event_handler_with_too_many_keyword_params_fails() -> None:
 
 def test_registering_before_handlers() -> None:
     @before_event("measure")
-    def before_measure(self, metrics: List[str] = [], control: servox.Control = None) -> None:
+    def before_measure(self, metrics: List[str] = [], control: Control = Control()) -> None:
         pass
 
     assert before_measure.__event_handler__.event.name == "measure"

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -470,7 +470,7 @@ def test_registering_event_handler_with_missing_positional_param_fails() -> None
     assert error
     assert (
         str(error.value)
-        == """invalid event handler "adjust": missing required parameter "adjustments" in callable signature "(self) -> servo.types.Description", expected "(self, adjustments: 'List[servo.types.Adjustment]', control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None)) -> 'servo.types.Description'\""""
+        == """invalid event handler "adjust": missing required parameter "adjustments" in callable signature "(self) -> servo.types.Description", expected "(self, adjustments: 'List[servo.types.Adjustment]', control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> 'servo.types.Description'\""""
     )
 
 
@@ -484,7 +484,7 @@ def test_registering_event_handler_with_missing_keyword_param_fails() -> None:
     assert error
     assert (
         str(error.value)
-        == """invalid event handler "measure": missing required parameter "metrics" in callable signature "(self, *, control: servo.types.Control = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None)) -> servo.types.Measurement", expected "(self, *, metrics: 'List[str]' = None, control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None)) -> 'servo.types.Measurement'\""""
+        == """invalid event handler "measure": missing required parameter "metrics" in callable signature "(self, *, control: servo.types.Control = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> servo.types.Measurement", expected "(self, *, metrics: 'List[str]' = None, control: 'servo.types.Control' = Control(duration=Duration('0'), delay=Duration('0'), warmup=Duration('0'), settlement=None, load=None, userdata=None, environment=None)) -> 'servo.types.Measurement'\""""
     )
 
 


### PR DESCRIPTION
(supersedes closed PR#311)

send control=Control(param['control']) when dispatching 'describe'
event, fix all existing handlers of 'describe' to have a matching arg, so they
can accept this change.

call 'before_event' handlers with the same data as on_event, fix all
existing 'before' handlers to accept this; modify handler type checking to 
compare 'before' handlers to the event's defined 'on' handler type, but with return type=None

add 'environment' to the types/Control() class (type =
Optional[dict[str, Any]])