### PR TITLE
Update prometheus metrics for opsani Dev removing _avg

### DIFF
--- a/servo/connectors/opsani_dev.py
+++ b/servo/connectors/opsani_dev.py
@@ -156,34 +156,34 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
                     query="sum(rate(envoy_cluster_upstream_rq_total[1m]))",
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_request_rate_avg",
+                    "main_request_rate",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role!="tuning"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "tuning_request_rate_avg",
+                    "tuning_request_rate",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_total{opsani_role="tuning"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_success_rate_avg",
+                    "main_success_rate",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"2|3"}[1m]))',
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "tuning_success_rate_avg",
+                    "tuning_success_rate",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"2|3"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "main_error_rate_avg",
+                    "main_error_rate",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role!="tuning", envoy_response_code_class=~"4|5"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero
                 ),
                 servo.connectors.prometheus.PrometheusMetric(
-                    "tuning_error_rate_avg",
+                    "tuning_error_rate",
                     servo.types.Unit.requests_per_second,
                     query='avg(rate(envoy_cluster_upstream_rq_xx{opsani_role="tuning", envoy_response_code_class=~"4|5"}[1m]))',
                     absent=servo.connectors.prometheus.AbsentMetricPolicy.zero


### PR DESCRIPTION
Rename _avg metrics to remove _avg name.