### PR TITLE
Make envoy proxy image name and tag configurable

### DIFF
--- a/servo/cli.py
+++ b/servo/cli.py
@@ -1711,11 +1711,11 @@ class ServoCLI(CLI):
         @self.command(section=section)
         def inject_sidecar(
             context: Context,
-            image: str = typer.Argument(
-                ..., help="Image of the sidecar to be injected in form [REPO]/[IMAGE]:[TAG]"
-            ),
             target: str = typer.Argument(
                 ..., help="Deployment or Pod to inject the sidecar on (deployment/NAME or pod/NAME)"
+            ),
+            image: str = typer.Option(
+                ..., "--image", "-i", help="Image of the sidecar to be injected in form [REPO]/[IMAGE]:[TAG]"
             ),
             namespace: str = typer.Option(
                 "default", "--namespace", "-n", help="Namespace of the target"

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -33,8 +33,6 @@ import servo
 import servo.runner
 import servo.utilities.yaml
 
-ENVOY_SIDECAR_IMAGE_TAG = 'opsani/envoy-proxy:servox-v0.9.0'
-
 class Section(str, enum.Enum):
     assembly = "Assembly Commands"
     ops = "Operational Commands"
@@ -1713,6 +1711,9 @@ class ServoCLI(CLI):
         @self.command(section=section)
         def inject_sidecar(
             context: Context,
+            image: str = typer.Argument(
+                ..., help="Image of the sidecar to be injected in form [REPO]/[IMAGE]:[TAG]"
+            ),
             target: str = typer.Argument(
                 ..., help="Deployment or Pod to inject the sidecar on (deployment/NAME or pod/NAME)"
             ),
@@ -1754,7 +1755,7 @@ class ServoCLI(CLI):
                 )
                 run_async(
                     deployment.inject_sidecar(
-                        'opsani-envoy', ENVOY_SIDECAR_IMAGE_TAG, service=service, port=port
+                        'opsani-envoy', image, service=service, port=port
                     )
                 )
                 typer.echo(f"Envoy sidecar injected to Deployment {deployment.name} in {namespace}")
@@ -1767,7 +1768,7 @@ class ServoCLI(CLI):
                 )
                 run_async(
                     rollout.inject_sidecar(
-                        'opsani-envoy', ENVOY_SIDECAR_IMAGE_TAG, service=service, port=port
+                        'opsani-envoy', image, service=service, port=port
                     )
                 )
                 typer.echo(f"Envoy sidecar injected to Rollout {rollout.name} in {namespace}")

--- a/servo/connectors/opsani_dev.py
+++ b/servo/connectors/opsani_dev.py
@@ -36,6 +36,7 @@ PROMETHEUS_ANNOTATION_DEFAULTS = {
     "prometheus.opsani.com/port": "9901",
 
 }
+ENVOY_SIDECAR_IMAGE_TAG = 'opsani/envoy-proxy:servox-v0.9.0'
 ENVOY_SIDECAR_LABELS = {
     "sidecar.opsani.com/type": "envoy"
 }
@@ -57,6 +58,7 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
     cpu: CPU
     memory: Memory
     prometheus_base_url: str = PROMETHEUS_SIDECAR_BASE_URL
+    envoy_sidecar_image: str = ENVOY_SIDECAR_IMAGE_TAG
     timeout: servo.Duration = "5m"
     settlement: Optional[servo.Duration] = pydantic.Field(
         description="Duration to observe the application after an adjust to ensure the deployment is stable. May be overridden by optimizer supplied `control.adjust.settlement` value."
@@ -642,7 +644,8 @@ class BaseOpsaniDevChecks(servo.BaseChecks, abc.ABC):
         )
         command = (
             f"kubectl exec -n {self.config.namespace} -c servo {self._servo_resource_target} -- "
-            f"servo --token-file /servo/opsani.token inject-sidecar --namespace {self.config.namespace} --service {self.config.service}{port_switch} "
+            f"servo --token-file /servo/opsani.token inject-sidecar --image {self.config.envoy_sidecar_image} "
+            f"--namespace {self.config.namespace} --service {self.config.service}{port_switch} "
             f"{self.controller_type_name.lower()}/{self.config_controller_name}"
         )
         raise servo.checks.CheckError(

--- a/servo/connectors/opsani_dev.py
+++ b/servo/connectors/opsani_dev.py
@@ -36,7 +36,7 @@ PROMETHEUS_ANNOTATION_DEFAULTS = {
     "prometheus.opsani.com/port": "9901",
 
 }
-ENVOY_SIDECAR_IMAGE_TAG = 'opsani/envoy-proxy:servox-v0.9.0'
+ENVOY_SIDECAR_IMAGE_TAG = 'opsani/envoy-proxy:v1.19-latest'
 ENVOY_SIDECAR_LABELS = {
     "sidecar.opsani.com/type": "envoy"
 }

--- a/tests/connectors/opsani_dev_test.py
+++ b/tests/connectors/opsani_dev_test.py
@@ -70,7 +70,7 @@ def rollout_checks(rollout_config: servo.connectors.opsani_dev.OpsaniDevConfigur
 class TestConfig:
     def test_generate(self) -> None:
         config = servo.connectors.opsani_dev.OpsaniDevConfiguration.generate()
-        assert list(config.dict().keys()) == ['description', 'namespace', 'deployment', 'rollout', 'container', 'service', 'port', 'cpu', 'memory', 'prometheus_base_url', 'timeout', 'settlement']
+        assert list(config.dict().keys()) == ['description', 'namespace', 'deployment', 'rollout', 'container', 'service', 'port', 'cpu', 'memory', 'prometheus_base_url', 'envoy_sidecar_image', 'timeout', 'settlement']
 
     def test_generate_yaml(self) -> None:
         config = servo.connectors.opsani_dev.OpsaniDevConfiguration.generate()


### PR DESCRIPTION
- move default envoy sidecar image tag from cli to opsani_dev connector
- make image a required argument of cli inject-sidecar command
- update opsani_dev configuration to allow setting of sidecar image