### PR TITLE
Made ServoX PEP 561 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 packages = [
     { include = "servo" },
 ]
-include = ["README.md", "CHANGELOG.md"]
+include = ["README.md", "CHANGELOG.md", "servo/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This lets us export the typehints so dependent packages can mypy deeply.

Sources:
- https://github.com/python-poetry/poetry/issues/1338#issuecomment-703737178
- https://gist.github.com/br3ndonland/987bdc6263217895d4bf03d0a5ff114c#pytyped
- https://www.python.org/dev/peps/pep-0561/