### PR TITLE
Update servox for new CICD setup

### DIFF
--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -19,6 +19,7 @@ import pathlib
 import re
 from typing import (
     Any,
+    AsyncIterator,
     Callable,
     ClassVar,
     Collection,
@@ -3574,6 +3575,15 @@ class CanaryOptimization(BaseOptimization):
 
         servo.logger.info(f"Tuning Pod successfully created")
         return tuning_pod
+
+    @contextlib.asynccontextmanager
+    async def temporary_tuning_pod(self) -> AsyncIterator[Pod]:
+        """Mostly used for testing where automatic teardown is not available"""
+        try:
+            tuning_pod = await self.create_tuning_pod()
+            yield tuning_pod
+        finally:
+            await self.delete_tuning_pod(raise_if_not_found=False)
 
     @property
     def tuning_cpu(self) -> Optional[CPU]:

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -936,7 +936,6 @@ def config(namespace: str) -> KubernetesConfiguration:
     )
 
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config")
 @pytest.mark.applymanifests("../manifests", files=["fiber-http-opsani-dev.yaml"])
 class TestKubernetesConnectorIntegration:
@@ -1482,7 +1481,6 @@ class TestKubernetesConnectorIntegration:
 ##
 # Rejection Tests using modified deployment, skips the standard manifest application
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config")
 class TestKubernetesConnectorIntegrationUnreadyCmd:
     @pytest.fixture
@@ -1737,7 +1735,6 @@ class TestKubernetesConnectorIntegrationUnreadyCmd:
 
 
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config")
 class TestKubernetesResourceRequirementsIntegration:
     @pytest.fixture(autouse=True)
@@ -2134,7 +2131,6 @@ class TestKubernetesResourceRequirementsIntegration:
 ENVOY_SIDECAR_IMAGE_TAG = 'opsani/envoy-proxy:servox-v0.9.0'
 
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config")
 class TestSidecarInjection:
     @pytest.fixture(autouse=True)
@@ -2357,7 +2353,6 @@ class TestSidecarInjection:
         ]
 
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config")
 class TestKubernetesClusterConnectorIntegration:
     """Tests not requiring manifests setup, just an active cluster
@@ -2399,7 +2394,6 @@ class TestKubernetesClusterConnectorIntegration:
 ##
 # Tests against an ArgoCD rollout
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config", "manage_rollout")
 @pytest.mark.parametrize((),[
     pytest.param(marks=pytest.mark.rollout_manifest.with_args("tests/manifests/argo_rollouts/fiber-http-opsani-dev.yaml")),
@@ -2566,7 +2560,6 @@ WORKLOAD_REF_ROLLOUT_EXPECTED_ENV = [
 ]
 
 @pytest.mark.integration
-@pytest.mark.clusterrolebinding('cluster-admin')
 @pytest.mark.usefixtures("kubernetes_asyncio_config", "manage_rollout")
 class TestRolloutSidecarInjection:
     @pytest.fixture


### PR DESCRIPTION
- Added CanaryOptimizaton.temporary_tuning_pod context manager to
facilitate test teardown
- Added kubetest_teardown to conftest for tests where namespace is not
created kubetest
- Update argo rollout test fixture to work with fewer permission
- Add xfail for intermittent threading issue test failure
- Drop cluster-admin rolebinding from tests
- Configure namespaces prometheus tests
- Add kubetest_teardown and tuning pod teardown to prometheus related
integration tests