### PR TITLE
Set kubernetes_asyncio back to official package

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -750,9 +750,9 @@ websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.0 || >=0.43.0"
 adal = ["adal (>=1.0.2)"]
 
 [[package]]
-name = "kubernetes-asyncio-cr-patch"
+name = "kubernetes-asyncio"
 version = "12.1.2"
-description = "Kubernetes asynchronous python client with patched custom resource API client"
+description = "Kubernetes asynchronous python client"
 category = "main"
 optional = false
 python-versions = "*"
@@ -1792,7 +1792,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9435c07cbd26681bee09e852e566b27c781a9e1b3ff2cfa958342a825104b347"
+content-hash = "278f879f7077ccb9bb7ed62655502dd2e010e3ee10c91391043cbc00b418ed9f"
 
 [metadata.files]
 aiohttp = [
@@ -2191,8 +2191,8 @@ kubernetes = [
     {file = "kubernetes-17.17.0-py3-none-any.whl", hash = "sha256:225a95a0aadbd5b645ab389d941a7980db8cdad2a776fde64d1b43fc3299bde9"},
     {file = "kubernetes-17.17.0.tar.gz", hash = "sha256:c69b318696ba797dcf63eb928a8d4370c52319f4140023c502d7dfdf2080eb79"},
 ]
-kubernetes-asyncio-cr-patch = [
-    {file = "kubernetes_asyncio_cr_patch-12.1.2.tar.gz", hash = "sha256:2e90c73b6cb3678eba397368c001bec27162f90e848aac71b3cfad9a476f938b"},
+kubernetes-asyncio = [
+    {file = "kubernetes_asyncio-12.1.2.tar.gz", hash = "sha256:dfff92cbeed37e81b0c94156162841a7a4ef3e95b00d521d50fe86a14f05fbf9"},
 ]
 kubetest = []
 loguru = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ toml = "^0.10.2"
 colorama = "^0.4.4"
 pyfiglet = "^0.8.post1"
 curlify2 = "^1.0.0"
-kubernetes-asyncio-cr-patch = "^12.1.2"
+kubernetes_asyncio = "^12.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"


### PR DESCRIPTION
- Update pyproject.toml and poetry.lock
- Add k8s connector missing explicit imports, alphabetize
- Update KubernetesModel.api_client context manager with default_headers
argument
- Set default_header content-type = application/merge-patch+json for
rollout patch method