### PR TITLE
Add container logs to restart count error messages

### DIFF
--- a/servo/connectors/kube_metrics.py
+++ b/servo/connectors/kube_metrics.py
@@ -143,7 +143,7 @@ class KubeMetricsChecks(servo.BaseChecks):
                         )
                         assert (
                             access_review.status.allowed
-                        ), f'Not allowed to "{verb}" resource "{resource}"'
+                        ), f'Not allowed to "{verb}" resource "{resource}" in group "{permission.group}"'
 
     @servo.require('Metrics API connectivity')
     async def check_metrics_api(self) -> None:

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -3826,7 +3826,7 @@ class CanaryOptimization(BaseOptimization):
                     await t
                     servo.logger.debug(f"Cancelled Task: {t}, progress: {progress}")
 
-            await self.raise_for_status()
+            await self.raise_for_status(tuning_pod=tuning_pod)
 
         # Load the in memory model for various convenience accessors
         await tuning_pod.refresh()
@@ -4091,9 +4091,11 @@ class CanaryOptimization(BaseOptimization):
         )
         return is_ready and restart_count == 0
 
-    async def raise_for_status(self) -> None:
+    async def raise_for_status(self, tuning_pod = None) -> None:
         """Raise an exception if in an unhealthy state."""
-        await self.tuning_pod.raise_for_status(
+        if tuning_pod is None:
+            tuning_pod = self.tuning_pod
+        await tuning_pod.raise_for_status(
             adjustments=self.adjustments,
             include_container_logs=self.target_controller_config.container_logs_in_error_status
         )

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -1019,7 +1019,8 @@ class Pod(KubernetesModel):
             )
         except kubernetes_asyncio.client.exceptions.ApiException as ae:
             if ae.status == 400:
-                status: kubernetes_asyncio.client.models.V1Status = api_client.api_client.deserialize(ae.body, "V1Status")
+                ae.data = ae.body
+                status: kubernetes_asyncio.client.models.V1Status = api_client.api_client.deserialize(ae, "V1Status")
                 if (status.message or "").endswith("not found"):
                     return "Logs not found"
 

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -1018,8 +1018,10 @@ class Pod(KubernetesModel):
                 previous=previous,
             )
         except kubernetes_asyncio.client.exceptions.ApiException as ae:
-            if ae.body.kind == "Status" and ae.body.code == 400 and (ae.body.message or "").endswith("not found"):
-                return "Logs not found"
+            if ae.status == 400:
+                status: kubernetes_asyncio.client.models.V1Status = api_client.api_client.deserialize(ae.body, "V1Status")
+                if (status.message or "").endswith("not found"):
+                    return "Logs not found"
 
             raise
 

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -1068,7 +1068,7 @@ class Pod(KubernetesModel):
         if restarted_container_statuses:
             container_logs: list[str] = ["DISABLED" for _ in restarted_container_statuses]
             if include_container_logs: # TODO enable logs config on per container basis
-                container_logs = self.get_logs_for_container_statuses(restarted_container_statuses)
+                container_logs = await self.get_logs_for_container_statuses(restarted_container_statuses)
             container_messages = [
                 (
                     f"{cont_stat.name} x{cont_stat.restart_count}"
@@ -2150,11 +2150,11 @@ class Deployment(KubernetesModel):
                         curstats.append(container_status)
                     else:
                         # Set up for next pod in list
-                        container_logs.extend(curpod.get_logs_for_container_statuses(curstats))
+                        container_logs.extend(await curpod.get_logs_for_container_statuses(curstats))
                         curpod = pod
                         curstats = [container_status]
                 # Get statuses for the last (or only) pod in the list
-                container_logs.extend(curpod.get_logs_for_container_statuses(curstats))
+                container_logs.extend(await curpod.get_logs_for_container_statuses(curstats))
 
             pod_to_counts = collections.defaultdict(list)
             for idx, (pod, cont_stat) in enumerate(restarted_pods_container_statuses):

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -3826,7 +3826,7 @@ class CanaryOptimization(BaseOptimization):
                     await t
                     servo.logger.debug(f"Cancelled Task: {t}, progress: {progress}")
 
-            await tuning_pod.raise_for_status(adjustments=self.adjustments)
+            await self.raise_for_status()
 
         # Load the in memory model for various convenience accessors
         await tuning_pod.refresh()

--- a/servo/connectors/opsani_dev.py
+++ b/servo/connectors/opsani_dev.py
@@ -66,6 +66,9 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
     settlement: Optional[servo.Duration] = pydantic.Field(
         description="Duration to observe the application after an adjust to ensure the deployment is stable. May be overridden by optimizer supplied `control.adjust.settlement` value."
     )
+    container_logs_in_error_status: bool = pydantic.Field(
+        False, description="Enable to include container logs in error message"
+    )
 
     @pydantic.root_validator
     def check_deployment_and_rollout(cls, values):
@@ -129,6 +132,7 @@ class OpsaniDevConfiguration(servo.BaseConfiguration):
             description="Update the namespace, deployment, etc. to match your Kubernetes cluster",
             timeout=self.timeout,
             settlement=self.settlement,
+            container_logs_in_error_status=self.container_logs_in_error_status,
             **main_arg,
             **kwargs,
         )

--- a/servo/types/__init__.py
+++ b/servo/types/__init__.py
@@ -1,5 +1,6 @@
 # Promote all symbols from submodules to the top-level package (TODO is this bad practice?)
 from .api import *
 from .core import *
+from .kubernetes import *
 from .settings import *
 from .slo import *

--- a/servo/types/kubernetes.py
+++ b/servo/types/kubernetes.py
@@ -1,0 +1,6 @@
+import enum
+
+class ContainerLogOptions(str, enum.Enum):
+    previous = "previous"
+    current = "current"
+    both = "both"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ filterwarnings =
     ignore: .*Using or importing the ABCs from 'collections':DeprecationWarning
     ignore: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead:DeprecationWarning
     ignore: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10:DeprecationWarning
+    ignore: distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning
     ignore: unclosed file <_io.TextIOWrapper name=.*:ResourceWarning
     ignore: unclosed file <_io.FileIO name=.*:ResourceWarning
     ignore: unclosed <ssl.SSLSocket .*:ResourceWarning

--- a/tests/connectors/opsani_dev_test.py
+++ b/tests/connectors/opsani_dev_test.py
@@ -73,7 +73,7 @@ class TestConfig:
         config = servo.connectors.opsani_dev.OpsaniDevConfiguration.generate()
         assert list(config.dict().keys()) == [
             'description', 'namespace', 'deployment', 'rollout', 'container', 'service','port', 'cpu', 'memory', 'env',
-            'static_environment_variables', 'prometheus_base_url', 'envoy_sidecar_image', 'timeout', 'settlement'
+            'static_environment_variables', 'prometheus_base_url', 'envoy_sidecar_image', 'timeout', 'settlement', 'container_logs_in_error_status'
         ]
 
     def test_generate_yaml(self) -> None:

--- a/tests/connectors/prometheus_test.py
+++ b/tests/connectors/prometheus_test.py
@@ -6,6 +6,7 @@ from typing import AsyncIterator
 
 import freezegun
 import httpx
+import kubetest.client
 import pydantic
 import pytest
 import pytz
@@ -373,8 +374,8 @@ class TestPrometheusIntegration:
         )
 
     @pytest.fixture(autouse=True)
-    def _wait_for_cluster(self, kube) -> None:
-        kube.wait_for_registered()
+    def _wait_for_cluster(self, kube: kubetest.client.TestClient) -> None:
+        kube.wait_for_registered(timeout=1800)
 
     async def test_targets(
         self,


### PR DESCRIPTION
- Add types module for kubernetes
- Implement new Pod method get_logs_for_container_statuses
- Add include_container_logs param to raise_for_status methods
- Include container logs in rejection messages for restart counts (
implementation for other failures TBD)
- Introduce container_logs_in_error_status flag to kubernetes config