### PR TITLE
Pin pydantic to 1.8.2 due to issue with "`Field`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = ["README.md", "CHANGELOG.md"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<=3.9.7"
-pydantic = "^1.8.1"
+pydantic = "1.8.2"
 loguru = "^0.5.1"
 httpx = "^0.17.0"
 python-dotenv = ">=0.15,<0.20"


### PR DESCRIPTION
default cannot be set in `Annotated`"