### PR TITLE
chore: update poetry install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ any Python package management system should work.
 
 * Clone the repo: `git clone git@github.com:opsani/servox`
 * Install required Python: `cd servox && pyenv install`
-* Install Poetry: `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py |
-  python`
+* Install Poetry: `curl -sSL https://install.python-poetry.org | python3 -`
+* Add Poetry to your path: `echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >> ~/.zshrc`
 * Link Poetry with pyenv version: ``poetry env use `cat .python-version` ``
 * Install dependencies: `poetry install`
 * Activate the venv: `poetry shell`


### PR DESCRIPTION
Bringing the install instructions in line with updated guidance on the [Poetry website](https://python-poetry.org/docs/master/#installation). Current instructions raise a warning that will soon become an error.