### PR TITLE
Optserv 606 optserv 608

### DIFF
--- a/servo/api.py
+++ b/servo/api.py
@@ -211,6 +211,9 @@ def adjustments_to_descriptor(
 
 def is_fatal_status_code(error: Exception) -> bool:
     if isinstance(error, httpx.HTTPStatusError):
+        # Include 404 in status codes to backoff on to reduce noise on CO when workload is not onboarded (OPTSERV-606)
+        if error.response.status_code == 404:
+            return False
         if error.response.status_code < 500:
             servo.logger.error(
                 f"Giving up on non-retryable HTTP status code {error.response.status_code} ({error.response.reason_phrase}) "

--- a/servo/checks.py
+++ b/servo/checks.py
@@ -890,6 +890,28 @@ class CheckHelpers(pydantic.BaseModel, servo.logging.Mixin):
 
         return output
 
+    @classmethod
+    def delay_generator(
+        cls,
+        delay: str,
+    ) -> Generator[float, None, None]:
+        if delay == "expo":
+
+            def delay_generator():
+                n = 3  # start with 8 second delay to roughly align with previous static default of 10 seconds
+                while True:
+                    yield 2**n
+                    n += 1
+
+        else:
+            static_duration = servo.Duration(delay).total_seconds()
+
+            def delay_generator():
+                while True:
+                    yield static_duration
+
+        return delay_generator()
+
 
 def _validate_check_handler(fn: CheckHandler) -> None:
     """

--- a/servo/configuration.py
+++ b/servo/configuration.py
@@ -579,7 +579,7 @@ class ChecksConfiguration(AbstractBaseConfiguration):
     wait: str = pydantic.Field(default="30m", description="Wait for checks to pass")
 
     delay: str = pydantic.Field(
-        default="10s", description="Delay duration. Requires --wait"
+        default="expo", description="Delay duration. Requires --wait"
     )
 
     halt_on: servo.types.ErrorSeverity = pydantic.Field(
@@ -637,7 +637,7 @@ class BaseServoConfiguration(AbstractBaseConfiguration, abc.ABC):
     """
 
     no_diagnostics: bool = pydantic.Field(
-        default=False, description="Do not poll the Opsani API for diagnostics"
+        default=True, description="Do not poll the Opsani API for diagnostics"
     )
 
     settings: Optional[CommonConfiguration] = pydantic.Field(

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -540,6 +540,7 @@ class Servo(servo.connector.BaseConnector):
         progressive = self.config.checks.progressive
         wait = self.config.checks.wait
         delay = self.config.checks.delay
+        delay_generator = servo.checks.CheckHelpers.delay_generator(delay=delay)
         halt_on = self.config.checks.halt_on
 
         # Validate that explicit args support check events
@@ -610,11 +611,12 @@ class Servo(servo.connector.BaseConnector):
             if ready:
                 return ready
             else:
-                if wait and delay is not None:
+                if wait:
+                    next_delay = next(delay_generator)
                     servo.logger.info(
-                        f"waiting for {delay} before rerunning failing checks"
+                        f"waiting for {next_delay} seconds before rerunning failing checks"
                     )
-                    await asyncio.sleep(servo.Duration(delay).total_seconds())
+                    await asyncio.sleep(next_delay)
 
                 if progress.finished:
                     # Don't log a timeout if we aren't running in wait mode

--- a/tests/connector_test.py
+++ b/tests/connector_test.py
@@ -1019,7 +1019,7 @@ def test_vegeta_cli_generate_with_defaults(
     config_file = tmp_path / "vegeta.yaml"
     config = yaml.full_load(config_file.read_text())
     assert config == {
-        "no_diagnostics": False,
+        "no_diagnostics": True,
         "optimizer": {
             "base_url": "https://api.opsani.com",
             "id": "generated-id.test/generated",
@@ -1047,7 +1047,7 @@ def test_vegeta_cli_generate_with_defaults(
         },
         "checks": {
             "check_halting": False,
-            "delay": "10s",
+            "delay": "expo",
             "halt_on": "critical",
             "progressive": True,
             "quiet": False,

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -758,7 +758,7 @@ class TestAssembly:
                     ],
                 },
                 "no_diagnostics": {
-                    "default": False,
+                    "default": True,
                     "description": "Do not poll the Opsani API for diagnostics",
                     "env_names": ["SERVO_NO_DIAGNOSTICS"],
                     "title": "No Diagnostics",
@@ -1101,7 +1101,7 @@ class TestAssembly:
                             "type": "array",
                         },
                         "delay": {
-                            "default": "10s",
+                            "default": "expo",
                             "description": "Delay duration. Requires --wait",
                             "env_names": ["CHECKS_DELAY"],
                             "title": "Delay",
@@ -2005,7 +2005,7 @@ def test_checks_defaults() -> None:
     assert checks_config.verbose == False
     assert checks_config.progressive == True
     assert checks_config.wait == Duration("30m")
-    assert checks_config.delay == Duration("10s")
+    assert checks_config.delay == "expo"
     assert checks_config.halt_on == ErrorSeverity.critical
     assert checks_config.remedy == True
     assert checks_config.check_halting == False


### PR DESCRIPTION
- Ensure backoff is applied to non-onboarded workloads to reduce noise
on CO
- Disable diagnostics calls to assets API in config defaults
- implement simple exponential backoff for checks to reduce noise in CO
from failing Opsani API Connectivity check