### PR TITLE
Optserv 690 implement handling for servo uid and command id into servox

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -22,6 +22,9 @@ metadata:
 data:
   log_level: {{ .Values.logLevel }}
   servo.yaml: |
+    {{- with .Values.servoUid }}
+    servo_uid: {{ . }}
+    {{- end }}
     optimizer:
       optimizer_id: {{ required ".Values.optimizerId is required" .Values.optimizerId }}
       {{- if eq .Values.connectionSettingsType "static" }}

--- a/servo/api.py
+++ b/servo/api.py
@@ -94,6 +94,7 @@ class Commands(str, enum.Enum):
 class Request(pydantic.BaseModel):
     event: Union[Events, str]  # TODO: Needs to be rethought -- used adhoc in some cases
     param: Optional[Dict[str, Any]]  # TODO: Switch to a union of supported types
+    servo_uid: Union[str, None] = None
 
     class Config:
         json_encoders = {
@@ -107,6 +108,9 @@ class Status(pydantic.BaseModel):
     reason: Optional[str] = None
     state: Optional[Dict[str, Any]] = None
     descriptor: Optional[Dict[str, Any]] = None
+    metrics: Union[dict[str, Any], None] = None
+    annotations: Union[dict[str, str], None] = None
+    command_uid: Union[str, None] = pydantic.Field(default=None, alias="cmd_uid")
 
     @classmethod
     def ok(
@@ -116,7 +120,7 @@ class Status(pydantic.BaseModel):
         return cls(status=ServoStatuses.ok, message=message, reason=reason, **kwargs)
 
     @classmethod
-    def from_error(cls, error: servo.errors.BaseError) -> "Status":
+    def from_error(cls, error: servo.errors.BaseError, **kwargs) -> "Status":
         """Return a status object representation from the given error."""
         if isinstance(error, servo.errors.AdjustmentRejectedError):
             status = ServoStatuses.rejected
@@ -127,15 +131,16 @@ class Status(pydantic.BaseModel):
         else:
             status = ServoStatuses.failed
 
-        return cls(status=status, message=str(error), reason=error.reason)
+        return cls(status=status, message=str(error), reason=error.reason, **kwargs)
 
     def dict(
         self,
         *,
         exclude_unset: bool = True,
+        by_alias: bool = True,
         **kwargs,
     ) -> DictStrAny:
-        return super().dict(exclude_unset=exclude_unset, **kwargs)
+        return super().dict(exclude_unset=exclude_unset, by_alias=by_alias, **kwargs)
 
 
 class SleepResponse(pydantic.BaseModel):
@@ -168,6 +173,7 @@ class MeasureParams(pydantic.BaseModel):
 
 class CommandResponse(pydantic.BaseModel):
     command: Commands = pydantic.Field(alias="cmd")
+    command_uid: Union[str, None] = pydantic.Field(alias="cmd_uid")
     param: Optional[
         Union[MeasureParams, Dict[str, Any]]
     ]  # TODO: Switch to a union of supported types, remove isinstance check from ServoRunner.measure when done

--- a/servo/api.py
+++ b/servo/api.py
@@ -142,6 +142,9 @@ class Status(pydantic.BaseModel):
     ) -> DictStrAny:
         return super().dict(exclude_unset=exclude_unset, by_alias=by_alias, **kwargs)
 
+    class Config:
+        allow_population_by_field_name = True
+
 
 class SleepResponse(pydantic.BaseModel):
     pass

--- a/servo/configuration.py
+++ b/servo/configuration.py
@@ -618,6 +618,7 @@ class BaseServoConfiguration(AbstractBaseConfiguration, abc.ABC):
 
     name: Optional[str] = None
     description: Optional[str] = None
+    servo_uid: Union[str, None] = None
     optimizer: OptimizerTypes = {}
     connectors: Optional[Union[List[str], Dict[str, str]]] = pydantic.Field(
         None,

--- a/servo/errors.py
+++ b/servo/errors.py
@@ -128,7 +128,11 @@ class EventError(ConnectorError):
 
 
 class UnexpectedEventError(EventError):
-    """The optimizer reported that an unexpected error was submitted."""
+    """The optimizer reported that an unexpected event was submitted."""
+
+
+class UnexpectedCommandIdError(EventError):
+    """The optimizer reported that an unexpected command ID was submitted."""
 
 
 class EventCancelledError(EventError):

--- a/servo/logging.py
+++ b/servo/logging.py
@@ -30,9 +30,9 @@ from typing import Any, Awaitable, Callable, Optional, Union
 
 import loguru
 
+import servo
 import servo.assembly
 import servo.events
-import servo.servo
 
 __all__ = (
     "Mixin",
@@ -136,7 +136,7 @@ class ProgressHandler:
                 )
             operation = event_context.operation()
 
-        command_uid: Union[str, None] = servo.servo.current_command_uid()
+        command_uid: Union[str, None] = servo.current_command_uid()
 
         started_at = extra.get("started_at", None)
         if not started_at:

--- a/servo/logging.py
+++ b/servo/logging.py
@@ -26,12 +26,13 @@ import pathlib
 import sys
 import time
 import traceback
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Union
 
 import loguru
 
 import servo.assembly
 import servo.events
+import servo.servo
 
 __all__ = (
     "Mixin",
@@ -135,6 +136,8 @@ class ProgressHandler:
                 )
             operation = event_context.operation()
 
+        command_uid: Union[str, None] = servo.servo.current_command_uid()
+
         started_at = extra.get("started_at", None)
         if not started_at:
             if event_context:
@@ -155,6 +158,7 @@ class ProgressHandler:
                 event_context=event_context,
                 started_at=started_at,
                 message=message,
+                command_uid=command_uid,
             )
         )
 

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -23,7 +23,17 @@ from datetime import datetime, timedelta
 import devtools
 import enum
 import json
-from typing import cast, Any, Callable, Optional, Protocol, Sequence, Tuple, Union
+from typing import (
+    cast,
+    Any,
+    Callable,
+    Iterable,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 import httpx
@@ -45,6 +55,9 @@ __all__ = ["Servo", "Events", "current_servo"]
 
 
 _current_context_var = contextvars.ContextVar("servox.current_servo", default=None)
+_current_command_uid_context_var = contextvars.ContextVar(
+    "servox.current_command_uid", default=None
+)
 
 
 def current_servo() -> Optional["Servo"]:
@@ -61,6 +74,19 @@ def _set_current_servo(servo_: Optional["Servo"]) -> None:
     The value is managed by a contextvar and is concurrency safe.
     """
     _current_context_var.set(servo_)
+
+
+def current_command_uid() -> Union[str, None]:
+    """Return the command ID that the current asyncio task was invoked under.
+
+    A new copy is automatically generated on creation of tasks and functions as a closure of the ID even after it is
+    updated by the main loop task
+    """
+    return _current_command_uid_context_var.get()
+
+
+def set_current_command_uid(value: Union[str, None]) -> None:
+    _current_command_uid_context_var.set(value)
 
 
 class Events(str, enum.Enum):
@@ -423,7 +449,11 @@ class Servo(servo.connector.BaseConnector):
             # Optimizer wants to cancel the operation
             raise servo.errors.EventCancelledError(status.reason or "Command cancelled")
         elif status.status == servo.api.OptimizerStatuses.invalid:
-            self.logger.warning(f"progress report was rejected as invalid")
+            self.logger.warning(
+                f"progress report was rejected as invalid: {devtools.pformat(status.dict())}"
+            )
+            if status.reason == "unexpected cmd_uid":
+                raise servo.errors.UnexpectedCommandIdError(status.reason)
         else:
             raise ValueError(f'unknown error status: "{status.status}"')
 
@@ -434,6 +464,7 @@ class Servo(servo.connector.BaseConnector):
         started_at: datetime,
         message: Optional[str],
         *,
+        command_uid: Union[str, None] = None,
         connector: Optional[str] = None,
         event_context: Optional["servo.events.EventContext"] = None,
         time_remaining: Optional[
@@ -465,6 +496,7 @@ class Servo(servo.connector.BaseConnector):
         params = dict(
             progress=float(progress),
             runtime=float(runtime.total_seconds()),
+            cmd_id=command_uid,
         )
         set_if(params, "message", message)
 
@@ -483,7 +515,9 @@ class Servo(servo.connector.BaseConnector):
         async def _post_event(
             event: Events, param
         ) -> Union[servo.api.CommandResponse, servo.api.Status]:
-            event_request = servo.api.Request(event=event, param=param)
+            event_request = servo.api.Request(
+                event=event, param=param, servo_uid=self.config.servo_uid
+            )
             self.logger.trace(
                 f"POST event request: {devtools.pformat(event_request.json())}"
             )
@@ -645,8 +679,19 @@ class Servo(servo.connector.BaseConnector):
             A list of check objects that describe the outcomes of the checks that were run.
         """
         try:
-            event_request = servo.api.Request(event=servo.api.Events.hello)
+            event_request = servo.api.Request(
+                event=servo.api.Events.hello, servo_uid=self.config.servo_uid
+            )
             response = await self._api_client.post("servo", data=event_request.json())
+            if (
+                response.status_code == 410
+                and response.json().get("detail") == "unexpected servo_uid"
+            ):
+                self.logger.warning(
+                    f"servo UID {self.config.servo_uid} is no longer valid. Waiting for deprovisioning (will sleep for 1 hour)"
+                )
+                await asyncio.sleep(3600)
+
             success = response.status_code == httpx.codes.OK
             return [
                 servo.checks.Check(

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -496,7 +496,7 @@ class Servo(servo.connector.BaseConnector):
         params = dict(
             progress=float(progress),
             runtime=float(runtime.total_seconds()),
-            cmd_id=command_uid,
+            cmd_uid=command_uid,
         )
         set_if(params, "message", message)
 

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -51,7 +51,7 @@ import servo.types
 import servo.utilities
 import servo.utilities.pydantic
 
-__all__ = ["Servo", "Events", "current_servo"]
+__all__ = ["Servo", "Events", "current_servo", "current_command_uid"]
 
 
 _current_context_var = contextvars.ContextVar("servox.current_servo", default=None)

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -787,6 +787,12 @@ class TestAssembly:
                         },
                     ],
                 },
+                "servo_uid": {
+                    "env": "SERVO_UID",
+                    "env_names": ["SERVO_UID"],
+                    "title": "Servo Uid",
+                    "type": "string",
+                },
                 "vegeta": {
                     "title": "Vegeta",
                     "env_names": [


### PR DESCRIPTION
- pass servo_uid from helm values to servo config yaml
- Add servo_uid to backend Request model
- Unify metrics response instantiation with other commands via Status.ok
- Allow setting arbitrary Status properties via from_error()
- Add command_uid to backend param Status model
- Add command_uid to backend CommandResponse model
- Add servo_uid to servo configuration model
- Add new error type for unexpected command uid
- Include command_uid in progress reporting logger sink
- Store command_uid returned by WHATS_NEXT into contextvar
- Send command_uid in command completions/errors
- Handle servo UID mismatch by sleeping for 1 hour wait for deprovision
- Add UnexpectedCommandIdError to progress exception restart handling
- Include servo_uid in startup logging
- Detect and raise UnexpectedCommandIdError in servo.report_progress
- Include servo_uid in all calls to post_event()
- Include servo_uid in servo check handler which bypasses post_event()
- Add functionality to override env_names with Field(env=...)