### PR TITLE
First pass update gather methods to prevent task leaks on error

### DIFF
--- a/servo/assembly.py
+++ b/servo/assembly.py
@@ -150,9 +150,9 @@ class Assembly(pydantic.BaseModel):
         )
 
         # Attach all connectors to the servo
-        await asyncio.gather(
-            *list(map(lambda s: s.dispatch_event(servo.servo.Events.attach, s), servos))
-        )
+        async with asyncio.TaskGroup() as tg:
+            for s in servos:
+                _ = tg.create_task(s.dispatch_event(servo.servo.Events.attach, s))
 
         return assembly
 

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -1133,12 +1133,12 @@ class ServoCLI(CLI):
                         results = run_async(gather_checks())
                         ready = functools.reduce(lambda x, y: x and y, results)
 
-                except servo.ConnectorNotFoundError as e:
+                except* servo.ConnectorNotFoundError as e:
                     typer.echo(
                         "A connector named within the checks config was not found in the current Assembly"
                     )
                     raise typer.Exit(1) from e
-                except servo.EventHandlersNotFoundError as e:
+                except* servo.EventHandlersNotFoundError as e:
                     typer.echo(
                         "At least one configured connector must respond to the Check event (Note the servo "
                         "responds to checks so this error should never raise unless something is well and truly wrong"

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -1141,27 +1141,15 @@ class CanaryOptimization(BaseOptimization):
             )
         )
         progress.start()
-
-        task = asyncio.create_task(PodHelper.wait_until_ready(tuning_pod))
-        task.add_done_callback(lambda _: progress.complete())
-        gather_task = asyncio.gather(
-            task,
-            progress.watch(progress_logger),
-        )
-
         try:
-            await asyncio.wait_for(gather_task, timeout=self.timeout.total_seconds())
+            async with asyncio.timeout(delay=self.timeout.total_seconds()):
+                async with asyncio.TaskGroup() as tg:
+                    task = tg.create_task(PodHelper.wait_until_ready(tuning_pod))
+                    task.add_done_callback(lambda _: progress.complete())
+                    _ = tg.create_task(progress.watch(progress_logger))
 
         except asyncio.TimeoutError:
             servo.logger.error(f"Timed out waiting for Tuning Pod to become ready...")
-            servo.logger.debug(f"Cancelling Task: {task}, progress: {progress}")
-            for t in {task, gather_task}:
-                t.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await t
-                    servo.logger.debug(f"Cancelled Task: {t}, progress: {progress}")
-
-            # get latest status of tuning pod for raise_for_status
             await self.raise_for_status()
 
         # Hydrate local state
@@ -1631,34 +1619,32 @@ class KubernetesOptimizations(pydantic.BaseModel, servo.logging.Mixin):
         # TODO: Run sanity checks to look for out of band changes
 
     async def raise_for_status(self) -> None:
-        handle_error_tasks = []
+        # TODO: first handle_error_task to raise will likely interrupt other tasks.
+        #   Gather with return_exceptions=True and aggregate resulting exceptions into group before raising
+        async with asyncio.TaskGroup() as tg:
 
-        def _raise_for_task(task: asyncio.Task, optimization: BaseOptimization) -> None:
-            if task.done() and not task.cancelled():
-                if exception := task.exception():
-                    handle_error_tasks.append(
-                        asyncio.create_task(optimization.handle_error(exception))
-                    )
+            def _raise_for_task(
+                task: asyncio.Task, optimization: BaseOptimization
+            ) -> None:
+                if task.done() and not task.cancelled():
+                    if exception := task.exception():
+                        _ = tg.create_task(optimization.handle_error(exception))
 
-        tasks = []
-        for optimization in self.optimizations:
-            task = asyncio.create_task(optimization.raise_for_status())
-            task.add_done_callback(
-                functools.partial(_raise_for_task, optimization=optimization)
-            )
-            tasks.append(task)
+            tasks = []
+            for optimization in self.optimizations:
+                task = asyncio.create_task(optimization.raise_for_status())
+                task.add_done_callback(
+                    functools.partial(_raise_for_task, optimization=optimization)
+                )
+                tasks.append(task)
 
-        for future in asyncio.as_completed(
-            tasks, timeout=self.config.timeout.total_seconds()
-        ):
-            try:
-                await future
-            except Exception as error:
-                servo.logger.exception(f"Optimization failed with error: {error}")
-
-        # TODO: first handler to raise will likely interrupt other tasks.
-        #   Gather with return_exceptions=True and aggregate resulting exceptions before raising
-        await asyncio.gather(*handle_error_tasks)
+            for future in asyncio.as_completed(
+                tasks, timeout=self.config.timeout.total_seconds()
+            ):
+                try:
+                    await future
+                except Exception as error:
+                    servo.logger.exception(f"Optimization failed with error: {error}")
 
     async def is_ready(self):
         if self.optimizations:
@@ -1666,14 +1652,13 @@ class KubernetesOptimizations(pydantic.BaseModel, servo.logging.Mixin):
                 f"Checking for readiness of {len(self.optimizations)} optimizations"
             )
             try:
-                results = await asyncio.wait_for(
-                    asyncio.gather(
-                        *list(map(lambda a: a.is_ready(), self.optimizations)),
-                    ),
-                    timeout=self.config.timeout.total_seconds(),
-                )
+                async with asyncio.timeout(delay=self.config.timeout.total_seconds()):
+                    async with asyncio.TaskGroup() as tg:
+                        results = [
+                            tg.create_task(o.is_ready()) for o in self.optimizations
+                        ]
 
-                return all(results)
+                return all((r.result() for r in results))
 
             except asyncio.TimeoutError:
                 return False
@@ -2297,15 +2282,13 @@ class KubernetesConnector(servo.BaseConnector):
             progress=p.progress,
         )
         progress = servo.EventProgress(timeout=self.config.timeout)
-        future = asyncio.create_task(state.apply(adjustments))
-        future.add_done_callback(lambda _: progress.trigger())
 
         # Catch-all for spaghettified non-EventError usage
         try:
-            await asyncio.gather(
-                future,
-                progress.watch(progress_logger),
-            )
+            async with asyncio.TaskGroup() as tg:
+                future = tg.create_task(state.apply(adjustments))
+                future.add_done_callback(lambda _: progress.trigger())
+                _ = tg.create_task(progress.watch(progress_logger))
 
             # Handle settlement
             settlement = control.settlement or self.config.settlement
@@ -2383,13 +2366,10 @@ class KubernetesConnector(servo.BaseConnector):
         )
         progress = servo.EventProgress(timeout=self.config.timeout)
         try:
-            future = asyncio.create_task(KubernetesOptimizations.create(self.config))
-            future.add_done_callback(lambda _: progress.trigger())
-
-            await asyncio.gather(
-                future,
-                progress.watch(progress_logger),
-            )
+            async with asyncio.TaskGroup() as tg:
+                future = tg.create_task(KubernetesOptimizations.create(self.config))
+                future.add_done_callback(lambda _: progress.trigger())
+                _ = tg.create_task(progress.watch(progress_logger))
 
             return future.result()
         except Exception as e:

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2334,7 +2334,7 @@ class KubernetesConnector(servo.BaseConnector):
 
             description = state.to_description()
         except ExceptionGroup as eg:
-            if any(isinstance(se, servo.EventError) for se in eg.exceptions):
+            if any(isinstance(sub_e, servo.EventError) for sub_e in eg.exceptions):
                 raise
             else:
                 raise servo.AdjustmentFailedError(str(eg.message)) from eg

--- a/servo/events.py
+++ b/servo/events.py
@@ -1016,7 +1016,7 @@ class _DispatchEvent:
                         **self._kwargs,
                     )
 
-                except servo.errors.EventCancelledError as error:
+                except* servo.errors.EventCancelledError as error:
                     # Return an empty result set
                     servo.logger.warning(
                         f'event cancelled by before event handler on connector "{connector.name}": {error}'

--- a/servo/events.py
+++ b/servo/events.py
@@ -1016,6 +1016,12 @@ class _DispatchEvent:
                         **self._kwargs,
                     )
 
+                except servo.errors.EventCancelledError as error:
+                    # Return an empty result set
+                    servo.logger.warning(
+                        f'event cancelled by before event handler on connector "{connector.name}": {error}'
+                    )
+                    return []
                 except ExceptionGroup as eg:
                     if any(
                         (

--- a/servo/events.py
+++ b/servo/events.py
@@ -1016,12 +1016,20 @@ class _DispatchEvent:
                         **self._kwargs,
                     )
 
-                except* servo.errors.EventCancelledError as error:
-                    # Return an empty result set
-                    servo.logger.warning(
-                        f'event cancelled by before event handler on connector "{connector.name}": {error}'
-                    )
-                    return []
+                except ExceptionGroup as eg:
+                    if any(
+                        (
+                            isinstance(se, servo.errors.EventCancelledError)
+                            for se in eg.exceptions
+                        )
+                    ):
+                        # Return an empty result set
+                        servo.logger.warning(
+                            f'event cancelled by before event handler on connector "{connector.name}": {eg}'
+                        )
+                        return []
+                    else:
+                        raise
 
         # Invoke the on event handlers and gather results
         if self._prepositions & Preposition.on:

--- a/servo/events.py
+++ b/servo/events.py
@@ -1011,7 +1011,7 @@ class _DispatchEvent:
             try:
                 async with asyncio.TaskGroup() as tg:
                     for connector in self._connectors:
-                        tg.create_task(
+                        _ = tg.create_task(
                             connector.run_event_handlers(
                                 self.event,
                                 Preposition.before,

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -745,7 +745,11 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
         except Exception as error:
             self.logger.critical(f"Failed assembly shutdown with error: {error}")
 
-        await asyncio.gather(self.progress_handler.shutdown(), return_exceptions=True)
+        try:
+            await self.progress_handler.shutdown()
+        except Exception as error:
+            self.logger.warning(f"Failed progress handler shutdown with error: {error}")
+
         self.logger.remove(self.progress_handler_id)
 
         # Cancel any outstanding tasks -- under a clean, graceful shutdown this list will be empty

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -160,7 +160,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     descriptor=description.__opsani_repr__(),
                     command_uid=cmd_response.command_uid,
                 )
-            except servo.errors.EventError as error:
+            except* servo.errors.EventError as error:
                 self.logger.error(f"Describe failed: {error}")
                 status = servo.api.Status.from_error(
                     error=error,
@@ -183,7 +183,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     command_uid=cmd_response.command_uid,
                     **measurement.__opsani_repr__(),
                 )
-            except servo.errors.EventError as error:
+            except* servo.errors.EventError as error:
                 self.logger.error(f"Measurement failed: {error}")
                 status = servo.api.Status.from_error(
                     error=error,
@@ -215,7 +215,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                 self.logger.success(
                     f"Adjusted: {components_count} components, {settings_count} settings"
                 )
-            except servo.EventError as error:
+            except* servo.EventError as error:
                 self.logger.error(f"Adjustment failed: {error}")
                 status = servo.api.Status.from_error(
                     error,
@@ -557,6 +557,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
                     )
                     return
 
+                # TODO try to abort a TaskGroup here
                 tasks = [
                     t for t in asyncio.all_tasks() if t is not asyncio.current_task()
                 ]
@@ -754,6 +755,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
 
         # Cancel any outstanding tasks -- under a clean, graceful shutdown this list will be empty
         # The shutdown of the assembly and the servo should clean up its tasks
+        # TODO try killing a task group here instead
         tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
         if len(tasks):
             [task.cancel() for task in tasks]

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -272,7 +272,7 @@ async def test_cancellation_of_event_from_before_handler(mocker, servo: Servo):
 
     # Mock the before handler to throw a cancel exception
     mock = mocker.patch.object(before_handler, "handler")
-    mock.side_effect = EventCancelledError("it burns when I pee")
+    mock.side_effect = EventCancelledError("it burns when I pee", connector=connector)
     results = await servo.dispatch_event("promote")
 
     # Check that on and after callbacks were never called
@@ -284,7 +284,7 @@ async def test_cancellation_of_event_from_before_handler(mocker, servo: Servo):
     assert messages[0].record["level"].name == "WARNING"
     assert (
         messages[0].record["message"]
-        == 'event cancelled by before event handler on connector "first_test_servo": it burns when I pee'
+        == "event cancelled by before event handler on connector \"first_test_servo\": (EventCancelledError('it burns when I pee'),)"
     )
 
 


### PR DESCRIPTION
This update replaces instances of gather() with (default behavior) return_exceptions=false since only the future that raises the exception will be stopped. TaskGroup ensures all taks complete or are cancelled before the with block is exited. This update is also applied to gather()s that are wrapped by task leak handling identical to TaskGroup to reduce the boilerplate added by said handling

This update is not applied to gather invocations that need to return (all) exceptions since that is not supported by TaskGroup. It is also not applied to gathers used as a shorthand for try catch pass logic (except for a case where logging was improved)

NOTE we avoid the use of create_task in generators in favor of list comprehensions which call create_task right away instead of lazily (doesn't matter for task result)

NOTE TaskGroup also prevents created task objects from being garbage collected by holding onto a reference which allows cleanup of variables for whose only purpose was ensuring the lifetime of the task reference matched the scope of its runtime