### PR TITLE
Optserv 1269 part 2 servox async logic hardening

### DIFF
--- a/servo/api.py
+++ b/servo/api.py
@@ -120,8 +120,12 @@ class Status(pydantic.BaseModel):
         return cls(status=ServoStatuses.ok, message=message, reason=reason, **kwargs)
 
     @classmethod
-    def from_error(cls, error: servo.errors.BaseError, **kwargs) -> "Status":
-        """Return a status object representation from the given error."""
+    def from_error(
+        cls, error: servo.errors.BaseError | ExceptionGroup, **kwargs
+    ) -> "Status":
+        """Return a status object representation from the given error (first if multiple in group)."""
+        if isinstance(error, ExceptionGroup):
+            error = error.exceptions[0]
         if isinstance(error, servo.errors.AdjustmentRejectedError):
             status = ServoStatuses.rejected
         elif isinstance(error, servo.errors.EventAbortedError):

--- a/servo/api.py
+++ b/servo/api.py
@@ -54,6 +54,16 @@ class ServoStatuses(enum.StrEnum):
     aborted = "aborted"
     cancelled = "cancelled"
 
+    def from_error(error: Exception) -> ServoStatuses:
+        if isinstance(error, servo.errors.AdjustmentRejectedError):
+            return ServoStatuses.rejected
+        elif isinstance(error, servo.errors.EventAbortedError):
+            return ServoStatuses.aborted
+        elif isinstance(error, servo.errors.EventCancelledError):
+            return ServoStatuses.cancelled
+        else:
+            return ServoStatuses.failed
+
 
 Statuses = Union[OptimizerStatuses, ServoStatuses]
 
@@ -127,38 +137,28 @@ class Status(pydantic.BaseModel):
         cls, error: servo.errors.BaseError | ExceptionGroup, **kwargs
     ) -> "Status":
         """Return a status object representation from the given error (first if multiple in group)."""
-        reason = getattr(error, "reason", ...)
         if isinstance(error, ExceptionGroup):
             servo.logger.warning(
                 f"from_error executed on exceptiongroup {error}. May produce undefined behavior"
             )
             status = ServoStatuses.failed
             try:
-                main_err = servo.errors.ServoError.servo_error_from_group(
+                error = servo.errors.ServoError.servo_error_from_group(
                     exception_group=error
                 )
-                if isinstance(main_err, list):
-                    main_err = main_err[0]
-                reason = main_err.reason
-            except:
+                if error._additional_errors:
+                    additional_messages = [str(e) for e in error._additional_errors]
+                    kwargs["additional_messages"] = (
+                        kwargs.get("additional_messages", []) + additional_messages
+                    )
+            except Exception:
                 servo.logger.exception(
                     "Failed to derive exceptiongroup reason for api response"
                 )
                 pass
-        if isinstance(error, servo.errors.AdjustmentRejectedError):
-            status = ServoStatuses.rejected
-        elif isinstance(error, servo.errors.EventAbortedError):
-            status = ServoStatuses.aborted
-        elif isinstance(error, servo.errors.EventCancelledError):
-            status = ServoStatuses.cancelled
-        else:
-            status = ServoStatuses.failed
 
-        if error._additional_errors:
-            additional_messages = [str(e) for e in error._additional_errors]
-            kwargs["additional_messages"] = (
-                kwargs.get("additional_messages", []) + additional_messages
-            )
+        reason = getattr(error, "reason", ...)
+        status = ServoStatuses.from_error(error)
 
         return cls(status=status, message=str(error), reason=reason, **kwargs)
 

--- a/servo/assembly.py
+++ b/servo/assembly.py
@@ -244,12 +244,12 @@ class Assembly(pydantic.BaseModel):
             )
         )
 
-    async def shutdown(self):
+    async def shutdown(self, reason: str | None = None):
         """Notify all servos that the assembly is shutting down."""
         await asyncio.gather(
             *list(
                 map(
-                    lambda s: s.shutdown(),
+                    lambda s: s.shutdown(reason=reason),
                     filter(
                         lambda s: s.is_running,
                         self.servos,

--- a/servo/assembly.py
+++ b/servo/assembly.py
@@ -119,29 +119,14 @@ class Assembly(pydantic.BaseModel):
 
             telemetry = servo.telemetry.Telemetry()
 
-            # Initialize all active connectors
-            connectors: List[servo.connector.BaseConnector] = []
-            for name, connector_type in routes.items():
-                connector_config = getattr(servo_config, name)
-                if connector_config is not None:
-                    connector = connector_type(
-                        name=name,
-                        config=connector_config,
-                        pubsub_exchange=pubsub_exchange,
-                        telemetry=telemetry,
-                        __connectors__=connectors,
-                    )
-                    connectors.append(connector)
-
             # Build the servo object
             servo_ = servo.servo.Servo(
                 config=servo_config,
-                connectors=connectors.copy(),  # Avoid self-referential reference to servo
                 telemetry=telemetry,
-                __connectors__=connectors,
                 pubsub_exchange=pubsub_exchange,
+                routes=routes,
             )
-            connectors.append(servo_)
+            servo_.load_connectors()
             servos.append(servo_)
 
         assembly = cls(
@@ -224,12 +209,14 @@ class Assembly(pydantic.BaseModel):
         """
         self.servos.append(servo_)
 
-        await servo.attach()
+        await servo_.attach()
 
         if self.is_running:
-            await servo.startup()
+            await servo_.startup()
 
-    async def remove_servo(self, servo_: servo.servo.Servo) -> None:
+    async def remove_servo(
+        self, servo_: servo.servo.Servo, reason: str | None = None
+    ) -> None:
         """Remove a servo from the assembly.
 
         Before removal, the servo is sent the detach event to prepare for
@@ -239,10 +226,10 @@ class Assembly(pydantic.BaseModel):
             servo_: The servo to remove from the assembly.
         """
 
-        await servo.detach()
+        await servo_.detach()
 
         if self.is_running:
-            await servo.shutdown()
+            await servo_.shutdown(reason)
 
         self.servos.remove(servo_)
 

--- a/servo/cli.py
+++ b/servo/cli.py
@@ -1150,9 +1150,9 @@ class ServoCLI(CLI):
 
             if not dry_run:
                 poll = not no_poll
-                servo.runner.AssemblyRunner(context.assembly).run(
-                    poll=poll,
-                    interactive=bool(interactive),
+                servo.runner.AssemblyRunner(
+                    context.assembly, poll=poll, interactive=bool(interactive)
+                ).run(
                     debug=debug,
                 )
 

--- a/servo/connectors/kube_metrics.py
+++ b/servo/connectors/kube_metrics.py
@@ -24,7 +24,7 @@ import os
 import pathlib
 import pydantic
 import time
-from typing import Any, Dict, List, Optional, FrozenSet, Union
+from typing import Annotated, Any, Dict, List, Optional, FrozenSet, Union
 
 import servo
 from servo.checks import CheckError
@@ -99,9 +99,9 @@ MAIN_METRICS_REQUIRE_CUST_OBJ: FrozenSet[SupportedKubeMetrics] = {
 
 
 class KubeMetricsConfiguration(servo.BaseConfiguration):
-    namespace: DNSSubdomainName = pydantic.Field(
-        description="Namespace of the target resource"
-    )
+    namespace: Annotated[
+        str, DNSSubdomainName(description="Namespace of the target resource")
+    ]
     name: str = pydantic.Field(description="Name of the target resource")
     kind: str = pydantic.Field(
         default="Deployment",

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2343,7 +2343,9 @@ class KubernetesConnector(servo.BaseConnector):
                             try:
                                 await state.raise_for_status()
                             except* servo.AdjustmentRejectedError as eg:
-                                e = eg.exceptions[0]
+                                e = servo.errors.ServoError.servo_error_from_group(eg)
+                                if isinstance(e, list):
+                                    e = e[0]
                                 # Update rejections with start-failed to indicate the initial rollout was successful
                                 if e.reason == "start-failed":
                                     e.reason = "unstable"

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2278,8 +2278,13 @@ class KubernetesConnector(servo.BaseConnector):
     async def describe(
         self, control: servo.Control = servo.Control()
     ) -> servo.Description:
-        state = await self._create_optimizations()
-        return state.to_description()
+        try:
+            state = await self._create_optimizations()
+            return state.to_description()
+        except ExceptionGroup as eg:
+            raise servo.ServoError.servo_error_from_group(
+                eg, default_error=servo.errors.EventError
+            ) from eg
 
     @servo.on_event()
     async def components(self) -> List[servo.Component]:

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -1673,22 +1673,8 @@ class KubernetesOptimizations(pydantic.BaseModel, servo.logging.Mixin):
 
 
 def DNSSubdomainName(description: str | None = None) -> Any:
-    return pydantic.Field(
-        strip_whitespace=True,
-        min_length=1,
-        max_length=253,
-        regex="^[0-9a-zA-Z]([0-9a-zA-Z\\.-])*[0-9A-Za-z]$",
-        description=description,
-    )
-
-
-# DNSSubdomainName = pydantic.constr(
-#     strip_whitespace=True,
-#     min_length=1,
-#     max_length=253,
-#     regex="^[0-9a-zA-Z]([0-9a-zA-Z\\.-])*[0-9A-Za-z]$",
-# )
-DNSSubdomainName.__doc__ = """DNSSubdomainName models a Kubernetes DNS Subdomain Name used as the name for most resource types.
+    """DNSSubdomainName returns a pydantic.Field that models a Kubernetes DNS Subdomain Name used as the name for most
+    resource types. Its only parameter allows specifying a custom description for the field when the model schema is dumped.
 
     Valid DNS Subdomain Names conform to [RFC 1123](https://tools.ietf.org/html/rfc1123) and must:
         * contain no more than 253 characters
@@ -1698,6 +1684,14 @@ DNSSubdomainName.__doc__ = """DNSSubdomainName models a Kubernetes DNS Subdomain
 
     See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
     """
+    return pydantic.Field(
+        strip_whitespace=True,
+        min_length=1,
+        max_length=253,
+        regex="^[0-9a-zA-Z]([0-9a-zA-Z\\.-])*[0-9A-Za-z]$",
+        description=description,
+    )
+
 
 DNSLabelNameField = pydantic.Field(
     strip_whitespace=True,
@@ -1706,12 +1700,6 @@ DNSLabelNameField = pydantic.Field(
     regex="^[0-9a-zA-Z]([0-9a-zA-Z-])*[0-9A-Za-z]$",
 )
 DNSLabelName = Annotated[str, DNSLabelNameField]
-# DNSLabelName = pydantic.constr(
-#     strip_whitespace=True,
-#     min_length=1,
-#     max_length=63,
-#     regex="^[0-9a-zA-Z]([0-9a-zA-Z-])*[0-9A-Za-z]$",
-# )
 DNSLabelName.__doc__ = """DNSLabelName models a Kubernetes DNS Label Name identified used to name some resource types.
 
     Valid DNS Label Names conform to [RFC 1123](https://tools.ietf.org/html/rfc1123) and must:

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2364,7 +2364,7 @@ class KubernetesConnector(servo.BaseConnector):
 
             description = state.to_description()
         except ExceptionGroup as eg:
-            if any(issubclass(sub_e, servo.EventError) for sub_e in eg.exceptions):
+            if any(issubclass(servo.EventError, sub_e) for sub_e in eg.exceptions):
                 raise
             else:
                 raise servo.AdjustmentFailedError(str(eg.message)) from eg

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2364,7 +2364,7 @@ class KubernetesConnector(servo.BaseConnector):
 
             description = state.to_description()
         except ExceptionGroup as eg:
-            if any(isinstance(sub_e, servo.EventError) for sub_e in eg.exceptions):
+            if any(issubclass(sub_e, servo.EventError) for sub_e in eg.exceptions):
                 raise
             else:
                 raise servo.AdjustmentFailedError(str(eg.message)) from eg

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -1699,15 +1699,13 @@ DNSSubdomainName.__doc__ = """DNSSubdomainName models a Kubernetes DNS Subdomain
     See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
     """
 
-DNSLabelName = Annotated[
-    str,
-    pydantic.Field(
-        strip_whitespace=True,
-        min_length=1,
-        max_length=63,
-        regex="^[0-9a-zA-Z]([0-9a-zA-Z-])*[0-9A-Za-z]$",
-    ),
-]
+DNSLabelNameField = pydantic.Field(
+    strip_whitespace=True,
+    min_length=1,
+    max_length=63,
+    regex="^[0-9a-zA-Z]([0-9a-zA-Z-])*[0-9A-Za-z]$",
+)
+DNSLabelName = Annotated[str, DNSLabelNameField]
 # DNSLabelName = pydantic.constr(
 #     strip_whitespace=True,
 #     min_length=1,
@@ -1726,15 +1724,13 @@ DNSLabelName.__doc__ = """DNSLabelName models a Kubernetes DNS Label Name identi
     """
 
 
-ContainerTagName = Annotated[
-    str,
-    pydantic.Field(
-        min_length=1,
-        max_length=128,
-        pattern="^[0-9a-zA-Z]([0-9a-zA-Z_\\.\\-/:@])*$",
-        strip_whitespace=True,
-    ),
-]
+ContainerTagNameField = pydantic.Field(
+    min_length=1,
+    max_length=128,
+    regex="^[0-9a-zA-Z]([0-9a-zA-Z_\\.\\-/:@])*$",
+    strip_whitespace=True,
+)
+ContainerTagName = Annotated[str, ContainerTagNameField]
 # ContainerTagName = pydantic.constr(
 #     min_length=1,
 #     max_length=128,

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2337,7 +2337,8 @@ class KubernetesConnector(servo.BaseConnector):
                             # Raise a specific exception if the optimization defines one
                             try:
                                 await state.raise_for_status()
-                            except* servo.AdjustmentRejectedError as e:
+                            except* servo.AdjustmentRejectedError as eg:
+                                e = eg.exceptions[0]
                                 # Update rejections with start-failed to indicate the initial rollout was successful
                                 if e.reason == "start-failed":
                                     e.reason = "unstable"

--- a/servo/connectors/kubernetes.py
+++ b/servo/connectors/kubernetes.py
@@ -2364,10 +2364,9 @@ class KubernetesConnector(servo.BaseConnector):
 
             description = state.to_description()
         except ExceptionGroup as eg:
-            if any(issubclass(servo.EventError, sub_e) for sub_e in eg.exceptions):
-                raise
-            else:
-                raise servo.AdjustmentFailedError(str(eg.message)) from eg
+            raise servo.ServoError.servo_error_from_group(
+                eg, default_error=servo.AdjustmentFailedError
+            ) from eg
         except servo.EventError:  # this is recognized by the runner
             raise
         except Exception as e:

--- a/servo/connectors/prometheus.py
+++ b/servo/connectors/prometheus.py
@@ -869,38 +869,38 @@ class PrometheusConnector(servo.BaseConnector):
 
     config: PrometheusConfiguration
 
-    @servo.on_event()
-    async def startup(self) -> None:
-        # Continuously publish a stream of metrics broadcasting every N seconds
-        streaming_interval = self.config.streaming_interval
-        if streaming_interval is not None:
-            logger = servo.logger.bind(component=f"{self.name} -> {CHANNEL}")
-            logger.info(f"Streaming Prometheus metrics every {streaming_interval}")
+    # @servo.on_event()
+    # async def startup(self) -> None:
+    #     # Continuously publish a stream of metrics broadcasting every N seconds
+    #     streaming_interval = self.config.streaming_interval
+    #     if streaming_interval is not None:
+    #         logger = servo.logger.bind(component=f"{self.name} -> {CHANNEL}")
+    #         logger.info(f"Streaming Prometheus metrics every {streaming_interval}")
 
-            @self.publish(CHANNEL, every=streaming_interval)
-            async def _publish_metrics(publisher: servo.pubsub.Publisher) -> None:
-                report = []
-                client = Client(base_url=self.config.base_url)
-                responses = await asyncio.gather(
-                    *list(map(client.query, self.config.metrics)),
-                    return_exceptions=True,
-                )
-                for response in responses:
-                    if isinstance(response, Exception):
-                        logger.error(
-                            f"failed querying Prometheus for metrics: {response}"
-                        )
-                        continue
+    #         @self.publish(CHANNEL, every=streaming_interval)
+    #         async def _publish_metrics(publisher: servo.pubsub.Publisher) -> None:
+    #             report = []
+    #             client = Client(base_url=self.config.base_url)
+    #             responses = await asyncio.gather(
+    #                 *list(map(client.query, self.config.metrics)),
+    #                 return_exceptions=True,
+    #             )
+    #             for response in responses:
+    #                 if isinstance(response, Exception):
+    #                     logger.error(
+    #                         f"failed querying Prometheus for metrics: {response}"
+    #                     )
+    #                     continue
 
-                    if response.data:
-                        # NOTE: Instant queries return a single vector
-                        timestamp, value = response.data[0].value
-                        report.append(
-                            (response.metric.name, timestamp.isoformat(), value)
-                        )
+    #                 if response.data:
+    #                     # NOTE: Instant queries return a single vector
+    #                     timestamp, value = response.data[0].value
+    #                     report.append(
+    #                         (response.metric.name, timestamp.isoformat(), value)
+    #                     )
 
-                await publisher(servo.pubsub.Message(json=report))
-                logger.debug(f"Published {len(report)} metrics.")
+    #             await publisher(servo.pubsub.Message(json=report))
+    #             logger.debug(f"Published {len(report)} metrics.")
 
     @servo.on_event()
     async def check(

--- a/servo/errors.py
+++ b/servo/errors.py
@@ -221,4 +221,5 @@ _ERROR_PRIORITIES = {
     MeasurementFailedError: 1,
     AdjustmentFailedError: 2,
     AdjustmentRejectedError: 3,
+    EventAbortedError: 4,
 }

--- a/servo/errors.py
+++ b/servo/errors.py
@@ -136,9 +136,13 @@ class ServoError(BaseError):
                 exc_list.append(exc)
 
         if top_error is None:
-            raise default_error(
-                message=str(exc_list[0]), additional_errors=exc_list
-            ) from exc_list[0]
+            try:
+                # raise from to capture full trace
+                raise default_error(
+                    message=str(exc_list[0]), additional_errors=exc_list
+                ) from exc_list[0]
+            except Exception as e:
+                return e
         else:
             top_error._additional_errors = exc_list
             return top_error
@@ -216,7 +220,7 @@ class EventAbortedError(EventError):
     """
 
 
-# Most errors have a default priority of 0
+# Higher numbers indicate a higher prioerity for the error. 0 is reserved for unrecognized exceptions
 _ERROR_PRIORITIES = {
     MeasurementFailedError: 1,
     AdjustmentFailedError: 2,

--- a/servo/events.py
+++ b/servo/events.py
@@ -27,6 +27,7 @@ import weakref
 from typing import (
     Any,
     AsyncContextManager,
+    AsyncGenerator,
     Awaitable,
     Callable,
     Dict,
@@ -364,7 +365,7 @@ def create_event(
 
     def _default_context_manager() -> AsyncContextManager:
         # Simply yield to the on event handler
-        async def fn(self) -> None:
+        async def fn(_) -> AsyncGenerator[None, None, None]:
             yield
 
         return contextlib.asynccontextmanager(fn)

--- a/servo/logging.py
+++ b/servo/logging.py
@@ -193,8 +193,8 @@ class ProgressHandler:
 
     async def _process_queue(self) -> None:
         while True:
+            progress = await self._queue.get()
             try:
-                progress = await self._queue.get()
                 if progress is None:
                     logger.info(
                         f"retrieved None from progress queue. halting progress reporting"

--- a/servo/logging.py
+++ b/servo/logging.py
@@ -347,6 +347,7 @@ DEFAULT_HANDLERS = [
 def set_level(level: str) -> None:
     """Set the logging threshold to the given level for all log handlers."""
     DEFAULT_FILTER.level = level
+    logging.getLogger("asyncio").setLevel(level)
 
 
 def set_colors(colors: bool) -> None:
@@ -368,8 +369,9 @@ def reset_to_defaults() -> None:
     loguru.logger.remove()
     loguru.logger.configure(handlers=DEFAULT_HANDLERS)
 
-    # Intercept messages from backoff library
+    # Intercept messages from other libraries
     logging.getLogger("backoff").addHandler(InterceptHandler())
+    logging.getLogger("asyncio").addHandler(InterceptHandler())
 
 
 def friendly_decorator(f):

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -630,7 +630,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
         else:
             self.logger.info(f"Shutting down {len(self.runners)} running servos...")
         for fut in asyncio.as_completed(
-            list(map(lambda r: r.shutdown(reason=reason), self.runners)), timeout=30.0
+            list(map(lambda r: r.shutdown(), self.runners)), timeout=30.0
         ):
             try:
                 await fut
@@ -642,7 +642,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
         # Shutdown the assembly and the servos it contains
         self.logger.debug("Dispatching shutdown event...")
         try:
-            await self.assembly.shutdown()
+            await self.assembly.shutdown(reason=reason)
         except Exception as error:
             self.logger.critical(f"Failed assembly shutdown with error: {error}")
 

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -363,11 +363,13 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
 
             if not self._main_loop_task.done():
                 self.logger.info(
-                    f"Cancelling ServoRunner _main_loop_task and running task_group: {self._task_group}"
+                    f"Cancelling ServoRunner _main_loop_task and running task_group: {self._task_group} _exiting {getattr(self._task_group, '_exiting')}"
                 )
                 self.logger.debug(
                     f"Current ServoRunner task group: {devtools.pformat(self._task_group)}"
                 )
+                self._main_loop_task.cancel()
+                await asyncio.gather(self._main_loop_task, return_exceptions=True)
 
         except Exception:
             self.logger.exception(f"Exception occurred during servo runner shutdown")

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -166,7 +166,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     command_uid=cmd_response.command_uid,
                 )
                 self.logger.error(f"Responding with {status.dict()}")
-                self.logger.opt(exception=error).debug("Describe failure details")
+                self.logger.opt(exception=error_group).debug("Describe failure details")
 
             self.clear_progress_queue()
             return await self.servo.post_event(servo.api.Events.describe, status.dict())
@@ -190,7 +190,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     command_uid=cmd_response.command_uid,
                 )
                 self.logger.error(f"Responding with {status.dict()}")
-                self.logger.opt(exception=error).debug("Measure failure details")
+                self.logger.opt(exception=error_group).debug("Measure failure details")
 
             self.clear_progress_queue()
             return await self.servo.post_event(servo.api.Events.measure, status.dict())
@@ -224,7 +224,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     command_uid=cmd_response.command_uid,
                 )
                 self.logger.error(f"Responding with {status.dict()}")
-                self.logger.opt(exception=error).debug("Adjust failure details")
+                self.logger.opt(exception=error_group).debug("Adjust failure details")
 
             self.clear_progress_queue()
             return await self.servo.post_event(servo.api.Events.adjust, status.dict())

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -22,7 +22,6 @@ import shutil
 import signal
 from typing import Any, Optional, Union
 
-import backoff
 import colorama
 import devtools
 import httpx
@@ -44,11 +43,9 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
     interactive: bool = False
     _assembly_runner: AssemblyRunner = pydantic.PrivateAttr(None)
     _servo: servo.Servo = pydantic.PrivateAttr(None)
-    _connected: bool = pydantic.PrivateAttr(False)
     _running: bool = pydantic.PrivateAttr(False)
     _main_loop_task: Optional[asyncio.Task] = pydantic.PrivateAttr(None)
-    _diagnostics_loop_task: Optional[asyncio.Task] = pydantic.PrivateAttr(None)
-    _file_watcher_task: Optional[asyncio.Task] = pydantic.PrivateAttr(None)
+    _task_group: Optional[asyncio.TaskGroup] = pydantic.PrivateAttr(None)
 
     class Config:
         arbitrary_types_allowed = True
@@ -74,7 +71,7 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
 
     @property
     def connected(self) -> bool:
-        return self._connected
+        return self.servo._connected
 
     @property
     def optimizer(
@@ -246,142 +243,47 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
             raise ValueError(f"Unknown command '{cmd_response.command.value}'")
 
     # Main run loop for processing commands from the optimizer
-    async def main_loop(self) -> None:
-        # FIXME: We have seen exceptions from using `with self.servo.current()` crossing contexts
-        _set_current_servo(self.servo)
-
-        while self.running:
-            try:
-                if self.interactive:
-                    if not typer.confirm("Poll for next command?"):
-                        typer.echo("Sleeping for 1m")
-                        await asyncio.sleep(60)
-                        continue
-
-                status = await self.exec_command()
-                if status.status == servo.api.OptimizerStatuses.unexpected_event:
-                    self.logger.warning(
-                        f"server reported unexpected event: {status.reason}"
-                    )
-
-            except httpx.TimeoutException as error:
-                self.logger.warning(
-                    f"command execution failed HTTP client timeout error: {error}"
-                )
-
-            except httpx.HTTPStatusError as error:
-                if (
-                    error.response.status_code == 410
-                    and error.response.json().get("detail") == "unexpected servo_uid"
-                ):
-                    self.logger.warning(
-                        f"servo UID {self.servo.config.servo_uid} is no longer valid. Waiting for deprovisioning (will sleep for 1 hour)"
-                    )
-                    await asyncio.sleep(3600)
-                else:
-                    self.logger.warning(
-                        f"command execution failed HTTP client status error: {error}"
-                    )
-
-            except pydantic.ValidationError as error:
-                self.logger.warning(
-                    f"command execution failed with model validation error: {error}"
-                )
-                self.logger.opt(exception=error).debug(
-                    "Pydantic model failed validation"
-                )
-
-            except Exception as error:
-                self.logger.exception(f"failed with unrecoverable error: {error}")
-                raise error
-
+    # FIXME: We have seen exceptions from using `with self.servo.current()` crossing contexts
     async def run_main_loop(self) -> None:
-        gather_cancelled = []
-        if self._main_loop_task and not self._main_loop_task.done():
-            self._main_loop_task.cancel()
-            gather_cancelled.append(self._main_loop_task)
+        async with asyncio.TaskGroup() as tg:
+            self._task_group = tg
 
-        if self._diagnostics_loop_task and not self._diagnostics_loop_task.done():
-            self._diagnostics_loop_task.cancel()
-            gather_cancelled.append(self._diagnostics_loop_task)
-
-        if self._file_watcher_task and not self._file_watcher_task.done():
-            self._file_watcher_task.cancel()
-            gather_cancelled.append(self._file_watcher_task)
-
-        if gather_cancelled:
-            await asyncio.create_task(
-                asyncio.gather(*gather_cancelled, return_exceptions=True)
-            )
-
-        def _reraise_if_necessary(task: asyncio.Task) -> None:
-            try:
-                if not task.cancelled():
-                    task.result()
-            except Exception as error:  # pylint: disable=broad-except
-                self.logger.error(
-                    f"Exiting from servo main loop due to error: {error} (task={task})"
+            if not servo.current_servo().config.no_diagnostics:
+                diagnostics_handler = servo.telemetry.DiagnosticsHandler(self.servo)
+                self._diagnostics_loop_task = self._task_group.create_task(
+                    diagnostics_handler.diagnostics_check(),
+                    name=f"diagnostics for servo {self.optimizer.id}",
                 )
-                self.logger.opt(exception=error).trace(
-                    f"Exception raised by task {task}"
+            else:
+                self.logger.info(
+                    f"Servo runner initialized with diagnostics polling disabled"
                 )
-                raise error  # Ensure that we surface the error for handling
 
-        self._main_loop_task = asyncio.create_task(
-            self.main_loop(), name=f"main loop for servo {self.optimizer.id}"
-        )
-        self._main_loop_task.add_done_callback(_reraise_if_necessary)
+            if getattr(self.optimizer, "connection_file", None):
+                self._file_watcher_task = self._task_group.create_task(
+                    self.servo.watch_connection_file(),
+                    name=f"connection file watcher for servo {self.optimizer.id}",
+                )
 
-        if not servo.current_servo().config.no_diagnostics:
-            diagnostics_handler = servo.telemetry.DiagnosticsHandler(self.servo)
-            self._diagnostics_loop_task = asyncio.create_task(
-                diagnostics_handler.diagnostics_check(),
-                name=f"diagnostics for servo {self.optimizer.id}",
-            )
-        else:
-            self.logger.info(
-                f"Servo runner initialized with diagnostics polling disabled"
-            )
-
-        if getattr(self.optimizer, "connection_file", None):
-            self._file_watcher_task = asyncio.create_task(
-                self.servo.watch_connection_file(),
-                name=f"connection file watcher for servo {self.optimizer.id}",
-            )
-
-    async def run(self, *, poll: bool = True) -> None:
-        self._running = True
-
-        _set_current_servo(self.servo)
-        await self.servo.startup()
-        self.logger.info(
-            f"Servo started with {len(self.servo.connectors)} active connectors [{self.optimizer.id} @ {self.optimizer.url or self.optimizer.base_url}]"
-        )
-
-        async def giveup(_: dict) -> None:
-            loop = asyncio.get_event_loop()
-            self.logger.critical("retries exhausted, giving up")
-            asyncio.create_task(self.shutdown())
-
-        try:
-
-            @backoff.on_exception(
-                backoff.expo,
-                httpx.HTTPError,
-                max_time=lambda: self.config.settings.backoff.max_time(),
-                max_tries=lambda: self.config.settings.backoff.max_tries(),
-                on_giveup=giveup,
-            )
-            async def connect() -> None:
-                self.logger.info("Saying HELLO.", end=" ")
+            while self.running:
                 try:
-                    await self.servo.post_event(
-                        servo.api.Events.hello,
-                        dict(
-                            agent=servo.api.user_agent(),
-                            telemetry=self.servo.telemetry.values,
-                        ),
+                    if self.interactive:
+                        if not typer.confirm("Poll for next command?"):
+                            typer.echo("Sleeping for 1m")
+                            await asyncio.sleep(60)
+                            continue
+
+                    status = await self.exec_command()
+                    if status.status == servo.api.OptimizerStatuses.unexpected_event:
+                        self.logger.warning(
+                            f"server reported unexpected event: {status.reason}"
+                        )
+
+                except httpx.TimeoutException as error:
+                    self.logger.warning(
+                        f"command execution failed HTTP client timeout error: {error}"
                     )
+
                 except httpx.HTTPStatusError as error:
                     if (
                         error.response.status_code == 410
@@ -392,43 +294,83 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                             f"servo UID {self.servo.config.servo_uid} is no longer valid. Waiting for deprovisioning (will sleep for 1 hour)"
                         )
                         await asyncio.sleep(3600)
-                    raise
+                    else:
+                        self.logger.warning(
+                            f"command execution failed HTTP client status error: {error}"
+                        )
 
-                self._connected = True
+                except pydantic.ValidationError as error:
+                    self.logger.warning(
+                        f"command execution failed with model validation error: {error}"
+                    )
+                    self.logger.opt(exception=error).debug(
+                        "Pydantic model failed validation"
+                    )
 
-            self.logger.info(
-                f"Connecting to Opsani Optimizer @ {self.optimizer.url}..."
-            )
-            if self.interactive:
-                typer.confirm("Connect to the optimizer?", abort=True)
+                except Exception as error:
+                    self.logger.exception(
+                        f"Exiting from servo main loop due to unrecoverable error: {error}"
+                    )
+                    raise error
 
-            await connect()
-        except typer.Abort:
-            # Rescue abort and notify user
-            servo.logger.warning("Operation aborted. Use Control-C to exit")
-        except asyncio.CancelledError as error:
-            self.logger.trace("task cancelled, aborting servo runner")
-            raise error
-        except:
-            self.logger.exception("exception encountered during connect")
+            raise asyncio.CancelledError("Main loop exited, cancelling task group")
+
+    async def run(self, *, poll: bool = True, startup: bool = True) -> None:
+        self._running = True
+        _set_current_servo(self.servo)
+
+        if startup:
+            try:
+                self.logger.info(
+                    f"Connecting to Opsani Optimizer @ {self.optimizer.url}..."
+                )
+                if self.interactive:
+                    typer.confirm("Connect to the optimizer?", abort=True)
+
+                await self.servo.startup()
+                self.logger.info(
+                    f"Servo started with {len(self.servo.connectors)} active connectors [{self.optimizer.id} @ {self.optimizer.url or self.optimizer.base_url}]"
+                )
+            except typer.Abort:
+                # Rescue abort and notify user
+                servo.logger.warning("Operation aborted. Use Control-C to exit")
+            except asyncio.CancelledError as error:
+                self.logger.trace("task cancelled, aborting servo runner")
+                raise error
+            except:
+                self.logger.exception("exception encountered during startup")
+                await self.shutdown()
+                return
 
         if poll:
-            await self.run_main_loop()
+            # block until exit or cancellation internally or externally
+            self._main_loop_task = asyncio.create_task(self.run_main_loop())
+            await self._main_loop_task
         else:
             self.logger.warning(
                 f"Servo runner initialized with polling disabled -- command loop is not running"
             )
 
-    async def shutdown(self, *, reason: Optional[str] = None) -> None:
+    async def shutdown(self, *, delay: float = 0.0) -> None:
         """Shutdown the running servo."""
         try:
+            self.logger.info("Shutting down servo runner")
             self._running = False
-            if self.connected:
-                await self.servo.post_event(
-                    servo.api.Events.goodbye, dict(reason=reason)
+
+            if delay > 0:
+                self.logger.info(f"waiting {delay} seconds for graceful shutdown")
+                await asyncio.sleep(delay=delay)
+
+            if not self._main_loop_task.done():
+                self.logger.info(
+                    f"Cancelling ServoRunner _main_loop_task and running task_group: {self._task_group}"
                 )
+                self.logger.debug(
+                    f"Current ServoRunner task group: {devtools.pformat(self._task_group)}"
+                )
+
         except Exception:
-            self.logger.exception(f"Exception occurred during GOODBYE request")
+            self.logger.exception(f"Exception occurred during servo runner shutdown")
 
     def clear_progress_queue(self) -> None:
         if self._assembly_runner and self._assembly_runner.progress_handler:
@@ -441,8 +383,13 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
     runners: list[ServoRunner] = []
     progress_handler: Optional[servo.logging.ProgressHandler] = None
     progress_handler_id: Optional[int] = None
+    poll: bool = True
+    interactive: bool = False
     _running: bool = pydantic.PrivateAttr(False)
     _shutting_down: bool = pydantic.PrivateAttr(False)
+    _root_task: asyncio.Task | None = pydantic.PrivateAttr(None)
+    _task_group: asyncio.TaskGroup | None = pydantic.PrivateAttr(None)
+    _runners_task_group: asyncio.TaskGroup | None = pydantic.PrivateAttr(None)
 
     class Config:
         arbitrary_types_allowed = True
@@ -465,9 +412,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
     def shutting_down(self) -> bool:
         return self._shutting_down
 
-    def run(
-        self, *, poll: bool = True, interactive: bool = False, debug: bool = False
-    ) -> None:
+    def run(self, *, debug: bool = False) -> None:
         """Asynchronously run all servos active within the assembly.
 
         Running the assembly takes over the current event loop and schedules a `ServoRunner` instance for each servo active in the assembly.
@@ -489,7 +434,7 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
         signals = (signal.SIGHUP, signal.SIGTERM, signal.SIGINT, signal.SIGUSR1)
         for s in signals:
             loop.add_signal_handler(
-                s, lambda s=s: asyncio.create_task(self._shutdown(loop, signal=s))
+                s, lambda s=s: loop.create_task(self.shutdown(loop, signal=s))
             )
 
         if not debug:
@@ -497,104 +442,53 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
         else:
             loop.set_exception_handler(None)
 
-        # Setup logging
-        async def _report_progress(**kwargs) -> None:
-            # Forward to the active servo...
-            if servo_ := servo.current_servo():
-                await servo_.report_progress(**kwargs)
-            else:
-                self.logger.warning(
-                    f"failed progress reporting -- no current servo context is established (kwargs={devtools.pformat(kwargs)})"
-                )
-
-        async def handle_progress_exception(
-            progress: dict[str, Any], error: Exception
-        ) -> None:
-            # FIXME: This needs to be made multi-servo aware
-            # Restart the main event loop if we get out of sync with the server
-            if isinstance(
-                error,
-                (
-                    servo.errors.UnexpectedEventError,
-                    servo.errors.EventCancelledError,
-                    servo.errors.UnexpectedCommandIdError,
-                ),
-            ) or (
-                isinstance(error, httpx.HTTPStatusError)
-                and error.response.status_code == 410
-                and error.response.json().get("detail")
-            ):
-                if isinstance(error, httpx.HTTPStatusError):
-                    self.logger.error(
-                        f"servo UID {servo.current_servo().config.servo_uid} is no longer valid: shutting down tasks to commence sleep loop"
-                    )
-                elif isinstance(error, servo.errors.UnexpectedEventError):
-                    self.logger.error(
-                        "servo has lost synchronization with the optimizer: restarting"
-                    )
-                elif isinstance(error, servo.errors.UnexpectedCommandIdError):
-                    self.logger.error(
-                        "servo is processing outdated command: restarting"
-                    )
-                elif isinstance(error, servo.errors.EventCancelledError):
-                    self.logger.error(
-                        "optimizer has cancelled operation in progress: cancelling and restarting loop"
-                    )
-
-                    # Post a status to resolve the operation
-                    operation = progress["operation"]
-                    command_uid = progress["command_uid"]
-                    status = servo.api.Status.from_error(
-                        error=error, command_uid=command_uid
-                    )
-                    self.logger.error(f"Responding with {status.dict()}")
-                    runner = self._runner_for_servo(servo.current_servo())
-                    await runner.servo.post_event(operation, status.dict())
-
-                if self.shutting_down:
-                    self.logger.warning(
-                        "restart attmempted during shutdown of servo. aborting restart"
-                    )
-                    return
-
-                # TODO try to abort a TaskGroup here
-                tasks = [
-                    t for t in asyncio.all_tasks() if t is not asyncio.current_task()
-                ]
-                self.logger.info(f"Cancelling {len(tasks)} outstanding tasks")
-                [task.cancel() for task in tasks]
-
-                await asyncio.gather(*tasks, return_exceptions=True)
-
-                # Restart a fresh main loop
-                if poll:
-                    runner = self._runner_for_servo(servo.current_servo())
-                    await runner.run_main_loop()
-
-            else:
-                self.logger.error(
-                    f"unrecognized exception passed to progress exception handler: {error}"
-                )
-
-        self.progress_handler = servo.logging.ProgressHandler(
-            _report_progress, self.logger.warning, handle_progress_exception
-        )
-        self.progress_handler_id = self.logger.add(self.progress_handler.sink)
-
-        self._display_banner()
-
         try:
-            for servo_ in self.assembly.servos:
-                servo_runner = ServoRunner(
-                    servo_, interactive=interactive, _assembly_runner=self
-                )
-                loop.create_task(servo_runner.run(poll=poll))
-                self.runners.append(servo_runner)
-
+            self._root_task = loop.create_task(self._run())
             loop.run_forever()
 
         finally:
             loop.close()
+
+    async def _run(self):
+        async with asyncio.TaskGroup() as tg:
+            self._task_group = tg
+            self.progress_handler = servo.logging.ProgressHandler(
+                self._report_progress,
+                self.logger.warning,
+                self._handle_progress_exception,
+                self._task_group,
+            )
+            self.progress_handler_id = self.logger.add(self.progress_handler.sink)
+
+            self._display_banner()
+
+            # Allow additional runners to be added to task group but stop running when all runners have finished
+            # TODO may need tweaks to work with progres exception
+            async with asyncio.TaskGroup() as runners_tg:
+                self._runners_task_group = runners_tg
+                for servo_ in self.assembly.servos:
+                    servo_runner = ServoRunner(
+                        servo_, interactive=self.interactive, _assembly_runner=self
+                    )
+
+                    _ = self._runners_task_group.create_task(
+                        servo_runner.run(poll=self.poll),
+                        name=f"runner for servo {servo_.optimizer.id}",
+                    )
+                    self.runners.append(servo_runner)
+
+            self.logger.info("All servo runners have completed, exiting")
+            raise asyncio.CancelledError("All servo runners have completed")
+
+    # Setup logging
+    async def _report_progress(self, **kwargs) -> None:
+        # Forward to the active servo...
+        if servo_ := servo.current_servo():
+            await servo_.report_progress(**kwargs)
+        else:
+            self.logger.warning(
+                f"failed progress reporting -- no current servo context is established (kwargs={devtools.pformat(kwargs)})"
+            )
 
     def _display_banner(self) -> None:
         fonts = [
@@ -713,9 +607,15 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
 
         secho(reset=True)
 
-    async def _shutdown(self, loop: asyncio.AbstractEventLoop, signal=None) -> None:
+    async def shutdown(self, loop: asyncio.AbstractEventLoop, signal=None) -> None:
         if not self.running:
             raise RuntimeError("Cannot shutdown an assembly that is not running")
+
+        if self._shutting_down:
+            self.logger.warning(
+                "AssemblyRunner already shutting down, ignoring redundant call"
+            )
+            return
 
         self._shutting_down = True
 
@@ -755,14 +655,23 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
 
         # Cancel any outstanding tasks -- under a clean, graceful shutdown this list will be empty
         # The shutdown of the assembly and the servo should clean up its tasks
-        # TODO try killing a task group here instead
-        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-        if len(tasks):
-            [task.cancel() for task in tasks]
-
-            self.logger.info(f"Cancelling {len(tasks)} outstanding tasks")
-            self.logger.debug(f"Outstanding tasks: {devtools.pformat(tasks)}")
-            await asyncio.gather(*tasks, return_exceptions=True)
+        if self._root_task is None:
+            self.logger.warning(
+                f"AssemblyRunner root_task set to None, skipping task cleanup (task_group: {self._task_group})"
+            )
+        elif self._root_task.done():
+            self.logger.info(
+                "AssemblyRunner root_task exited gracefully after shutdown"
+            )
+        else:
+            self.logger.info(
+                f"Cancelling AssemblyRunner root_task and running task_group: {self._task_group}"
+            )
+            self.logger.debug(
+                f"Current AssemblyRunner task group: {devtools.pformat(self._task_group)}"
+            )
+            self._root_task.cancel()
+            await asyncio.gather(self._root_task, return_exceptions=True)
 
         self.logger.info("Servo shutdown complete.")
         await asyncio.gather(self.logger.complete(), return_exceptions=True)
@@ -781,13 +690,82 @@ class AssemblyRunner(pydantic.BaseModel, servo.logging.Mixin):
 
         if isinstance(exception, asyncio.CancelledError):
             logger.warning(f"ignoring asyncio.CancelledError exception")
-            pass
         elif loop.is_closed():
             logger.critical("Ignoring exception -- the event loop is closed.")
         elif self.running:
             logger.critical(
-                "Shutting down due to unhandled exception in asyncio event loop..."
+                f"Shutting down due to unhandled exception {exception} in asyncio event loop..."
             )
-            loop.create_task(self._shutdown(loop))
+            loop.create_task(self.shutdown(loop))
         else:
             logger.critical("Ignoring exception -- the assembly is not running")
+
+    async def _handle_progress_exception(
+        self, progress: dict[str, Any], error: Exception
+    ) -> None:
+        # FIXME: This needs to be made multi-servo aware
+        # Restart the main event loop if we get out of sync with the server
+        ###### TODO get current servo and call its shutdown instead of task reaping
+        if isinstance(
+            error,
+            (
+                servo.errors.UnexpectedEventError,
+                servo.errors.EventCancelledError,
+                servo.errors.UnexpectedCommandIdError,
+            ),
+        ) or (
+            isinstance(error, httpx.HTTPStatusError)
+            and error.response.status_code == 410
+            and error.response.json().get("detail")
+        ):
+            servo_ = progress["servo"]
+            if isinstance(error, httpx.HTTPStatusError):
+                self.logger.error(
+                    f"servo UID {servo.current_servo().config.servo_uid} is no longer valid: shutting down tasks to commence sleep loop"
+                )
+            elif isinstance(error, servo.errors.UnexpectedEventError):
+                self.logger.error(
+                    "servo has lost synchronization with the optimizer: restarting"
+                )
+            elif isinstance(error, servo.errors.UnexpectedCommandIdError):
+                self.logger.error("servo is processing outdated command: restarting")
+            elif isinstance(error, servo.errors.EventCancelledError):
+                self.logger.error(
+                    "optimizer has cancelled operation in progress: cancelling and restarting loop"
+                )
+
+                # Post a status to resolve the operation
+                operation = progress["operation"]
+                command_uid = progress["command_uid"]
+                status = servo.api.Status.from_error(
+                    error=error, command_uid=command_uid
+                )
+                self.logger.error(f"Responding with {status.dict()}")
+                await servo_.post_event(operation, status.dict())
+
+            if self.shutting_down:
+                self.logger.warning(
+                    "restart attmempted during shutdown of servo. aborting restart"
+                )
+                return
+
+            runner = self._runner_for_servo(servo_)
+            # stop servo main loop
+            await runner.shutdown()
+            # call detach and shutdown
+            await self.assembly.remove_servo(self.servo, reason="restarting")
+
+            # Restart a fresh main loop
+            if self.poll:
+                servo_.load_connectors()
+                # call attach and startup
+                await self.assembly.add_servo(servo_)
+                _ = self._runners_task_group.create_task(
+                    runner.run(poll=self.poll),
+                    name=f"runner for servo {servo_.optimizer.id}",
+                )
+
+        else:
+            self.logger.error(
+                f"unrecognized exception passed to progress exception handler: {error}"
+            )

--- a/servo/runner.py
+++ b/servo/runner.py
@@ -157,10 +157,11 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     descriptor=description.__opsani_repr__(),
                     command_uid=cmd_response.command_uid,
                 )
-            except* servo.errors.EventError as error:
-                self.logger.error(f"Describe failed: {error}")
+            except* servo.errors.EventError as error_group:
+                self.logger.error(f"Describe failed: {error_group.exceptions}")
+                top_error = servo.errors.ServoError.servo_error_from_group(error_group)
                 status = servo.api.Status.from_error(
-                    error=error,
+                    error=top_error,
                     command_uid=cmd_response.command_uid,
                 )
                 self.logger.error(f"Responding with {status.dict()}")
@@ -180,10 +181,11 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                     command_uid=cmd_response.command_uid,
                     **measurement.__opsani_repr__(),
                 )
-            except* servo.errors.EventError as error:
-                self.logger.error(f"Measurement failed: {error}")
+            except* servo.errors.EventError as error_group:
+                self.logger.error(f"Measurement failed: {error_group.exceptions}")
+                top_error = servo.errors.ServoError.servo_error_from_group(error_group)
                 status = servo.api.Status.from_error(
-                    error=error,
+                    error=top_error,
                     command_uid=cmd_response.command_uid,
                 )
                 self.logger.error(f"Responding with {status.dict()}")
@@ -212,10 +214,12 @@ class ServoRunner(pydantic.BaseModel, servo.logging.Mixin):
                 self.logger.success(
                     f"Adjusted: {components_count} components, {settings_count} settings"
                 )
-            except* servo.EventError as error:
-                self.logger.error(f"Adjustment failed: {error}")
+            except* servo.errors.EventError as error_group:
+                self.logger.error(f"Adjustment failed: {error_group.exceptions}")
+                self.logger.error(f"Describe failed: {error_group.exceptions}")
+                top_error = servo.errors.ServoError.servo_error_from_group(error_group)
                 status = servo.api.Status.from_error(
-                    error,
+                    error=top_error,
                     command_uid=cmd_response.command_uid,
                 )
                 self.logger.error(f"Responding with {status.dict()}")

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -220,7 +220,7 @@ class Servo(servo.connector.BaseConnector):
     """
 
     routes: dict[str, type[servo.connector.BaseConnector]] = {}
-    """The dict of connectors this servo was initially configured with. Used for adding connectors that have been removed
+    """The dict of connectors this servo was initially configured with. Used for storing the connectors to be added to this servo on initialization and re-start
     """
 
     _api_client: Union[httpx.AsyncClient, AsyncOAuth2Client] = pydantic.PrivateAttr(

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -241,9 +241,11 @@ class Servo(servo.connector.BaseConnector):
         self,
         *args,
         connectors: list[servo.connector.BaseConnector] | None = None,
-        __connectors__=[],
+        __connectors__: list[servo.connector.BaseConnector] | None = None,
         **kwargs,
     ) -> None:  # noqa: D107
+        if __connectors__ is None:
+            __connectors__ = []
         super().__init__(*args, connectors=[], __connectors__=__connectors__, **kwargs)
 
         self._api_client = servo.api.get_api_client_for_optimizer(

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -219,12 +219,17 @@ class Servo(servo.connector.BaseConnector):
     """The active connectors in the Servo.
     """
 
+    routes: dict[str, type[servo.connector.BaseConnector]] = {}
+    """The dict of connectors this servo was initially configured with. Used for adding connectors that have been removed
+    """
+
     _api_client: Union[httpx.AsyncClient, AsyncOAuth2Client] = pydantic.PrivateAttr(
         None
     )
     """An asynchronous client for interacting with the Opsani API."""
 
     _running: bool = pydantic.PrivateAttr(False)
+    _connected: bool = pydantic.PrivateAttr(False)
 
     async def dispatch_event(
         self, *args, **kwargs
@@ -233,19 +238,23 @@ class Servo(servo.connector.BaseConnector):
             return await super().dispatch_event(*args, **kwargs)
 
     def __init__(
-        self, *args, connectors: list[servo.connector.BaseConnector], **kwargs
+        self,
+        *args,
+        connectors: list[servo.connector.BaseConnector] | None = None,
+        **kwargs,
     ) -> None:  # noqa: D107
-        super().__init__(*args, connectors=[], **kwargs)
+        super().__init__(*args, connectors=[], __connectors__=[], **kwargs)
 
         self._api_client = servo.api.get_api_client_for_optimizer(
             self.config.optimizer, self.config.settings
         )
 
-        # Ensure the connectors refer to the same objects by identity (required for eventing)
-        self.connectors.extend(connectors)
+        if connectors:
+            # Ensure the connectors refer to the same objects by identity (required for eventing)
+            self.connectors.extend(connectors)
 
         # associate shared config with our children
-        for connector in connectors + [self]:
+        for connector in self.connectors + [self]:
             connector._global_config = self.config.settings
             connector._optimizer = self.config.optimizer
 
@@ -257,6 +266,30 @@ class Servo(servo.connector.BaseConnector):
             )
 
         return values
+
+    def load_connectors(self):
+        if not self.routes:
+            raise RuntimeError("No routes configured to load connectors for")
+
+        # Initialize all active connectors
+        for name, connector_type in self.routes.items():
+            connector_config = getattr(self.config, name)
+            if connector_config is not None:
+                connector = connector_type(
+                    name=name,
+                    config=connector_config,
+                    pubsub_exchange=self.pubsub_exchange,
+                    telemetry=self.telemetry,
+                    __connectors__=self.__connectors__,
+                )
+                # associate shared config with our children
+                connector._global_config = self.config.settings
+                connector._optimizer = self.config.optimizer
+
+                self.__connectors__.append(connector)
+                self.connectors.append(connector)
+
+        self.__connectors__.append(self)
 
     async def attach(self, servo_: servo.assembly.Assembly) -> None:
         """Notify the servo that it has been attached to an Assembly."""
@@ -276,17 +309,20 @@ class Servo(servo.connector.BaseConnector):
         if self.is_running:
             raise RuntimeError("Cannot start up a servo that is already running")
 
+        await self.connect()
+
         self._running = True
 
         await self.dispatch_event(
             Events.startup, _prepositions=servo.events.Preposition.on
         )
 
+        # TODO remove pubsub logic
         # Start up the pub/sub exchange
         if not self.pubsub_exchange.running:
             self.pubsub_exchange.start()
 
-    async def shutdown(self) -> None:
+    async def shutdown(self, reason: str | None = None) -> None:
         """Notify all active connectors that the servo is shutting down."""
         if not self.is_running:
             raise RuntimeError("Cannot shut down a servo that is not running")
@@ -297,6 +333,11 @@ class Servo(servo.connector.BaseConnector):
         # Shut down the pub/sub exchange
         if self.pubsub_exchange.running:
             await self.pubsub_exchange.shutdown()
+
+        # Notifiy the backend we are shutting down
+        if reason is None:
+            reason = "unknown"
+        await self.disconnect(reason=reason)
 
         self._running = False
 
@@ -434,6 +475,50 @@ class Servo(servo.connector.BaseConnector):
             indent=2,
             default=pydantic.json.pydantic_encoder,
         )
+
+    async def connect(self) -> None:
+        # must define dynamic function to allow configurable backoff
+        await backoff.on_exception(
+            backoff.expo,
+            httpx.HTTPError,
+            max_time=lambda: self.config.settings.backoff.max_time(),
+            max_tries=lambda: self.config.settings.backoff.max_tries(),
+            on_giveup=lambda details: self.logger.critical(
+                f"retries exhausted after {details['elapsed']} seconds, giving up"
+            ),
+        )(self.try_connect)()
+
+    async def try_connect(self) -> None:
+        self.logger.info("Saying HELLO.", end=" ")
+        try:
+            await self.post_event(
+                servo.api.Events.hello,
+                dict(
+                    agent=servo.api.user_agent(),
+                    telemetry=self.telemetry.values,
+                ),
+            )
+        except httpx.HTTPStatusError as error:
+            if (
+                error.response.status_code == 410
+                and error.response.json().get("detail") == "unexpected servo_uid"
+            ):
+                self.logger.warning(
+                    f"servo UID {self.config.servo_uid} is no longer valid. Waiting for deprovisioning (will sleep for 1 hour)"
+                )
+                await asyncio.sleep(3600)
+            raise
+
+        self._connected = True
+
+    async def disconnect(self, reason: str) -> None:
+        if self._connected:
+            try:
+                await self.post_event(servo.api.Events.goodbye, dict(reason=reason))
+            except:
+                self.logger.exception("Failed to send GOODBYE event")
+
+            self._connected = False
 
     async def report_progress(self, **kwargs) -> None:
         """Post a progress report to the Opsani API."""

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -492,7 +492,7 @@ class Servo(servo.connector.BaseConnector):
         )(self.try_connect)()
 
     async def try_connect(self) -> None:
-        self.logger.info("Saying HELLO.", end=" ")
+        self.logger.info("Saying HELLO.")
         try:
             await self.post_event(
                 servo.api.Events.hello,

--- a/servo/servo.py
+++ b/servo/servo.py
@@ -241,9 +241,10 @@ class Servo(servo.connector.BaseConnector):
         self,
         *args,
         connectors: list[servo.connector.BaseConnector] | None = None,
+        __connectors__=[],
         **kwargs,
     ) -> None:  # noqa: D107
-        super().__init__(*args, connectors=[], __connectors__=[], **kwargs)
+        super().__init__(*args, connectors=[], __connectors__=__connectors__, **kwargs)
 
         self._api_client = servo.api.get_api_client_for_optimizer(
             self.config.optimizer, self.config.settings
@@ -550,12 +551,14 @@ class Servo(servo.connector.BaseConnector):
         message: Optional[str],
         *,
         command_uid: Union[str, None] = None,
-        connector: Optional[str] = None,
-        event_context: Optional["servo.events.EventContext"] = None,
         time_remaining: Optional[
             Union[servo.types.Numeric, servo.types.Duration]
         ] = None,
-        logs: Optional[list[str]] = None,
+        **kwargs
+        # logs: Optional[list[str]] = None,
+        # _servo: Optional[Servo] = None,
+        # connector: Optional[servo.connector.BaseConnector] = None,
+        # event_context: Optional["servo.events.EventContext"] = None,
     ) -> Tuple[str, dict[str, Any]]:
         def set_if(d: dict, k: str, v: Any):
             if v is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,9 @@ import servo.connectors.kubernetes
 import tests.helpers
 
 # Add the devtools debug() function globally in tests
-builtins.debug = devtools.debug
+from devtools import debug
+
+builtins.debug = debug
 
 # Render all manifests as Mustache templates by default
 kubetest.manifest.__render__ = chevron.render
@@ -467,7 +469,7 @@ def random_string() -> str:
 
 
 @pytest.fixture
-def captured_logs() -> list["loguru.Message"]:
+def captured_logs() -> Generator[None, list["loguru.Message"], None]:
     messages = []
     temp_sink_id = servo.logger.add(lambda m: messages.append(m), level=0)
     yield messages
@@ -531,7 +533,11 @@ async def kubernetes_asyncio_config(
 
 
 @pytest.fixture
-async def minikube(request, subprocess, kubeconfig: pathlib.Path) -> str:
+async def minikube(
+    request: pytest.FixtureRequest,
+    subprocess: tests.helpers.Subprocess,
+    kubeconfig: pathlib.Path,
+) -> AsyncGenerator[str, None]:
     """Run tests within a local minikube profile.
 
     The profile name is determined using the parametrized `minikube_profile` marker
@@ -632,10 +638,13 @@ async def fakeapi_url(
     fastapi_app: fastapi.FastAPI, unused_tcp_port: int
 ) -> AsyncGenerator[str, None]:
     """Run a FakeAPI server as a pytest fixture and yield the base URL for accessing it."""
-    server = tests.helpers.FakeAPI(app=fastapi_app, port=unused_tcp_port)
-    await server.start()
-    yield server.base_url
-    await server.stop()
+    async with asyncio.TaskGroup() as tg:
+        server = tests.helpers.FakeAPI(
+            app=fastapi_app, port=unused_tcp_port, task_group=tg
+        )
+        await server.start()
+        yield server.base_url
+        await server.stop()
 
 
 @pytest.fixture
@@ -741,28 +750,28 @@ async def kubectl_ports_forwarded(
     ports_arg = " ".join(list(map(lambda pair: f"{pair[0]}:{pair[1]}", ports)))
     context_arg = f"--context {context}" if context else ""
     event = asyncio.Event()
-    task = asyncio.create_task(
-        tests.helpers.Subprocess.shell(
-            f"kubectl --kubeconfig={kubeconfig} {context_arg} port-forward --namespace {namespace} {identifier} {ports_arg}",
-            event=event,
-            print_output=True,
-        )
-    )
-
-    await event.wait()
-
-    # Check the sockets can be connected to
-    # TODO/FIXME add fault tolerance for error upgrading connection: unable to upgrade connection: pod does not exist
-    for local_port, _ in ports:
-        a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        if (h_errno := a_socket.connect_ex(("localhost", local_port))) != 0:
-            if task.done():
-                debug(task.result())
-            raise RuntimeError(
-                f"port forwarding failed: port {local_port} connect failed (errno {h_errno})"
+    async with asyncio.TaskGroup() as tg:
+        task = tg.create_task(
+            tests.helpers.Subprocess.shell(
+                f"kubectl --kubeconfig={kubeconfig} {context_arg} port-forward --namespace {namespace} {identifier} {ports_arg}",
+                event=event,
+                print_output=True,
             )
+        )
 
-    try:
+        await event.wait()
+
+        # Check the sockets can be connected to
+        # TODO/FIXME add fault tolerance for error upgrading connection: unable to upgrade connection: pod does not exist
+        for local_port, _ in ports:
+            a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            if (h_errno := a_socket.connect_ex(("localhost", local_port))) != 0:
+                if task.done():
+                    debug(task.result())
+                raise RuntimeError(
+                    f"port forwarding failed: port {local_port} connect failed (errno {h_errno})"
+                )
+
         if len(ports) == 1:
             url = f"http://localhost:{ports[0][0]}"
             yield url
@@ -772,10 +781,8 @@ async def kubectl_ports_forwarded(
                 map(lambda p: (p[1], f"http://localhost:{p[0]}"), ports)
             )
             yield ports_to_urls
-    finally:
+
         task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -677,9 +677,14 @@ async def assembly(servo_yaml: pathlib.Path) -> servo.assembly.Assembly:
 
 
 @pytest.fixture
-def assembly_runner(assembly: servo.Assembly) -> servo.runner.AssemblyRunner:
+async def assembly_runner(
+    assembly: servo.Assembly,
+) -> AsyncGenerator[servo.runner.AssemblyRunner, None]:
     """Return an unstarted assembly runner."""
-    return servo.runner.AssemblyRunner(assembly)
+    runner = servo.runner.AssemblyRunner(assembly)
+    yield runner
+    if runner.progress_handler is not None:
+        await runner.progress_handler.shutdown()
 
 
 @pytest.fixture

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -36,9 +36,11 @@ from servo.connectors.kubernetes import (
     CanaryOptimizationStrategyConfiguration,
     ContainerConfiguration,
     ContainerTagName,
+    ContainerTagNameField,
     DefaultOptimizationStrategyConfiguration,
     DeploymentConfiguration,
     DNSLabelName,
+    DNSLabelNameField,
     DNSSubdomainName,
     FailureMode,
     KubernetesChecks,
@@ -120,10 +122,10 @@ class TestDNSSubdomainName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSSubdomainName().regex.pattern}"',
+            "msg": f'string does not match regex "{DNSSubdomainName().regex}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSSubdomainName().regex.pattern,
+                "pattern": DNSSubdomainName().regex,
             },
         } in e.value.errors()
 
@@ -137,10 +139,10 @@ class TestDNSSubdomainName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSSubdomainName().regex.pattern}"',
+            "msg": f'string does not match regex "{DNSSubdomainName().regex}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSSubdomainName().regex.pattern,
+                "pattern": DNSSubdomainName().regex,
             },
         } in e.value.errors()
 
@@ -154,10 +156,10 @@ class TestDNSSubdomainName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSSubdomainName().regex.pattern}"',
+            "msg": f'string does not match regex "{DNSSubdomainName().regex}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSSubdomainName().regex.pattern,
+                "pattern": DNSSubdomainName().regex,
             },
         } in e.value.errors()
 
@@ -218,10 +220,10 @@ class TestDNSLabelName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSLabelName.regex.pattern}"',
+            "msg": f'string does not match regex "{DNSLabelNameField.regex}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSLabelName.regex.pattern,
+                "pattern": DNSLabelNameField.regex,
             },
         } in e.value.errors()
 
@@ -235,10 +237,10 @@ class TestDNSLabelName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSLabelName.regex.pattern}"',
+            "msg": f'string does not match regex "{DNSLabelNameField.regex}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSLabelName.regex.pattern,
+                "pattern": DNSLabelNameField.regex,
             },
         } in e.value.errors()
 
@@ -252,10 +254,10 @@ class TestDNSLabelName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSLabelName.regex.pattern}"',
+            "msg": f'string does not match regex "{DNSLabelNameField.regex}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSLabelName.regex.pattern,
+                "pattern": DNSLabelNameField.regex,
             },
         } in e.value.errors()
 
@@ -312,10 +314,10 @@ class TestContainerTagName:
             assert e
             assert {
                 "loc": ("name",),
-                "msg": f'string does not match regex "{ContainerTagName.regex.pattern}"',
+                "msg": f'string does not match regex "{ContainerTagNameField.regex}"',
                 "type": "value_error.str.regex",
                 "ctx": {
-                    "pattern": ContainerTagName.regex.pattern,
+                    "pattern": ContainerTagNameField.regex,
                 },
             } in e.value.errors()
 

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1555,7 +1555,7 @@ class TestKubernetesConnectorIntegration:
         # Check error
         assert "quantities must match the regular expression" in str(error.value)
         top_cause = unwrap_exception_group(
-            error.value.__cause__, aiohttp.ClientResponseError
+            error.value.__cause__, kubernetes_asyncio.client.ApiException
         )
         if isinstance(top_cause, list):
             top_cause = top_cause[0]

--- a/tests/connectors/kubernetes_test.py
+++ b/tests/connectors/kubernetes_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Type
+from typing import Annotated, Type
 
 import httpx
 import kubetest.client
@@ -68,7 +68,7 @@ class TestDNSSubdomainName:
     @pytest.fixture
     def model(self) -> Type[BaseModel]:
         class Model(BaseModel):
-            name: DNSSubdomainName
+            name: Annotated[str, DNSSubdomainName()]
 
         return Model
 
@@ -120,10 +120,10 @@ class TestDNSSubdomainName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSSubdomainName.regex.pattern}"',
+            "msg": f'string does not match regex "{DNSSubdomainName().regex.pattern}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSSubdomainName.regex.pattern,
+                "pattern": DNSSubdomainName().regex.pattern,
             },
         } in e.value.errors()
 
@@ -137,10 +137,10 @@ class TestDNSSubdomainName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSSubdomainName.regex.pattern}"',
+            "msg": f'string does not match regex "{DNSSubdomainName().regex.pattern}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSSubdomainName.regex.pattern,
+                "pattern": DNSSubdomainName().regex.pattern,
             },
         } in e.value.errors()
 
@@ -154,10 +154,10 @@ class TestDNSSubdomainName:
         assert e
         assert {
             "loc": ("name",),
-            "msg": f'string does not match regex "{DNSSubdomainName.regex.pattern}"',
+            "msg": f'string does not match regex "{DNSSubdomainName().regex.pattern}"',
             "type": "value_error.str.regex",
             "ctx": {
-                "pattern": DNSSubdomainName.regex.pattern,
+                "pattern": DNSSubdomainName().regex.pattern,
             },
         } in e.value.errors()
 

--- a/tests/connectors/opsani_dev_test.py
+++ b/tests/connectors/opsani_dev_test.py
@@ -662,10 +662,10 @@ class TestNoTuningIntegration:
             await assert_check(no_tuning_checks.run_one(id=f"check_tuning_is_running"))
 
             # Cancel outstanding tasks
-            tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-            [task.cancel() for task in tasks]
+            # tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+            # [task.cancel() for task in tasks]
 
-            await asyncio.gather(*tasks, return_exceptions=True)
+            # await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @pytest.mark.integration
@@ -1178,12 +1178,12 @@ class TestServiceMultiport:
                     )
 
                 # Cancel outstanding tasks
-                tasks = [
-                    t for t in asyncio.all_tasks() if t is not asyncio.current_task()
-                ]
-                [task.cancel() for task in tasks]
+                # tasks = [
+                #     t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+                # ]
+                # [task.cancel() for task in tasks]
 
-                await asyncio.gather(*tasks, return_exceptions=True)
+                # await asyncio.gather(*tasks, return_exceptions=True)
 
         @pytest.mark.namespace(create=False, name="test-install-wait")
         async def test_install_wait(

--- a/tests/connectors/prometheus_test.py
+++ b/tests/connectors/prometheus_test.py
@@ -1,5 +1,5 @@
 import datetime
-import devtools
+from devtools import debug, pprint
 import json
 import pathlib
 import re
@@ -588,7 +588,7 @@ class TestPrometheusIntegration:
                     timeout=360,  # NOTE: if we haven't returned in 5 minutes all is lost
                 )
                 assert measurement
-                assert len(measurement) == 1, devtools.pprint(measurement)
+                assert len(measurement) == 1, pprint(measurement)
                 time_series = measurement[0]
 
                 # Check that the readings are zero on both sides of the measurement but not in between
@@ -737,16 +737,16 @@ class TestPrometheusIntegration:
                             ),
                         )
                         # Send traffic in the background
-                        traffic_task = asyncio.create_task(send_traffic())
-
-                        try:
-                            measurement = await asyncio.wait_for(
-                                connector.measure(control=control), timeout=90
-                            )
-                            assert measurement
-                        finally:
+                        async with asyncio.TaskGroup() as tg:
+                            _ = tg.create_task(send_traffic())
+                            async with asyncio.timeout(90):
+                                measure_task = tg.create_task(
+                                    connector.measure(control=control)
+                                )
+                                measurement = await measure_task
                             sending_traffic = False
-                            await traffic_task
+
+                        assert measurement
 
     @pytest.mark.applymanifests(
         "../manifests",
@@ -855,35 +855,36 @@ class TestPrometheusIntegration:
                             ),
                         )
                         # Send traffic in the background
-                        traffic_task = asyncio.create_task(send_traffic())
+                        async with asyncio.TaskGroup() as tg:
+                            _ = tg.create_task(send_traffic())
 
-                        date_matcher = r"[\s0-9-:.]*"
-                        float_matcher = r"[0-9.]*"
-                        error_text = (
-                            re.escape(
-                                "SLO violation(s) observed: (tuning_p50_latency below 0.2)["
+                            date_matcher = r"[\s0-9-:.]*"
+                            float_matcher = r"[0-9.]*"
+                            error_text = (
+                                re.escape(
+                                    "SLO violation(s) observed: (tuning_p50_latency below 0.2)["
+                                )
+                                + date_matcher
+                                + "SLO failed metric value "
+                                + float_matcher
+                                + re.escape(" was not below threshold value 0.2, ")
+                                + date_matcher
+                                + "SLO failed metric value "
+                                + float_matcher
+                                + re.escape(" was not below threshold value 0.2]")
                             )
-                            + date_matcher
-                            + "SLO failed metric value "
-                            + float_matcher
-                            + re.escape(" was not below threshold value 0.2, ")
-                            + date_matcher
-                            + "SLO failed metric value "
-                            + float_matcher
-                            + re.escape(" was not below threshold value 0.2]")
-                        )
 
-                        try:
                             with pytest.raises(
                                 servo.errors.EventAbortedError, match=error_text
                             ):
-                                measurement = await asyncio.wait_for(
-                                    connector.measure(control=control), timeout=90
+                                measure_task = tg.create_task(
+                                    connector.measure(control=control)
                                 )
-                                debug(measurement)
-                        finally:
+                                async with asyncio.timeout(90):
+                                    measurement = await measure_task
+                                    debug(measurement)
+
                             sending_traffic = False
-                            await traffic_task
 
 
 def empty_targets_response() -> Dict[str, Any]:

--- a/tests/connectors/prometheus_test.py
+++ b/tests/connectors/prometheus_test.py
@@ -29,6 +29,8 @@ from servo.connectors.prometheus import (
 )
 from servo.types import *
 
+import tests.helpers
+
 
 class TestPrometheusMetric:
     def test_accepts_step_as_duration(self):
@@ -875,8 +877,8 @@ class TestPrometheusIntegration:
                             )
 
                             with pytest.raises(
-                                servo.errors.EventAbortedError, match=error_text
-                            ):
+                                ExceptionGroup, match=error_text
+                            ) as excg:
                                 measure_task = tg.create_task(
                                     connector.measure(control=control)
                                 )
@@ -885,6 +887,10 @@ class TestPrometheusIntegration:
                                     debug(measurement)
 
                             sending_traffic = False
+                            aborted_error = tests.helpers.unwrap_exception_group(
+                                excg, servo.errors.EventAbortedError, 1
+                            )
+                            assert re.search(error_text, str(aborted_error)) is not None
 
 
 def empty_targets_response() -> Dict[str, Any]:

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -1,7 +1,7 @@
 import datetime
 import pathlib
 import random
-from typing import Optional, Union
+from typing import AsyncGenerator, Optional, Union
 
 import fastapi
 import pytest
@@ -283,9 +283,14 @@ async def assembly(
 
 
 @pytest.fixture
-def assembly_runner(assembly: servo.Assembly) -> servo.runner.AssemblyRunner:
+async def assembly_runner(
+    assembly: servo.Assembly,
+) -> AsyncGenerator[servo.runner.AssemblyRunner, None]:
     """Return an unstarted assembly runner."""
-    return servo.runner.AssemblyRunner(assembly)
+    runner = servo.runner.AssemblyRunner(assembly)
+    yield runner
+    if runner.progress_handler is not None:
+        await runner.progress_handler.shutdown()
 
 
 @pytest.fixture

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,6 +18,7 @@ from typing import (
     Type,
     Union,
 )
+import typing
 
 import fastapi
 import httpx
@@ -179,6 +180,28 @@ def json_key_path(json_str: str, key_path: str) -> Any:
     """
     obj = json.loads(json_str)
     return dict_key_path(obj, key_path)
+
+
+E = typing.TypeVar("E")
+
+
+def unwrap_exception_group(
+    excg: ExceptionGroup, expected_type: type[E], expected_count: int | None = None
+) -> E | list[E]:
+    excg_len = len(excg.exceptions)
+    if expected_count is not None:
+        assert (
+            excg_len == expected_count
+        ), f"Excpetion group count {excg_len} did not match expected count {expected_count}"
+
+    assert excg_len > 0
+    assert all(
+        isinstance(e, expected_type) for e in excg.exceptions
+    ), f"Group did not contain only expected type {expected_type}: {excg.exceptions}"
+    if excg_len > 1:
+        return list(excg.exceptions)
+    else:
+        return excg.exceptions[0]
 
 
 class Subprocess:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -20,7 +20,9 @@ from typing import (
 )
 
 import fastapi
+import httpx
 import kubernetes_asyncio.client
+import respx
 import uvicorn
 import yaml
 from pydantic.json import pydantic_encoder
@@ -236,6 +238,12 @@ class Subprocess:
             log_output=log_output,
             **kwargs,
         )
+
+
+api_mock = respx.mock(base_url="https://api.opsani.com/", assert_all_called=True)
+api_mock.post("/accounts/dev.opsani.com/applications/servox/servo", name="servo").mock(
+    return_value=httpx.Response(200, json={"status": "ok", "command": "SLEEP"}),
+)
 
 
 class FakeAPI(uvicorn.Server):

--- a/tests/logging_test.py
+++ b/tests/logging_test.py
@@ -158,7 +158,9 @@ class TestProgressHandler:
 
     @pytest.fixture()
     def logger(self, handler: ProgressHandler) -> loguru.Logger:
-        logger = loguru.logger.bind(connector="progress")
+        logger = loguru.logger.bind(
+            connector="progress", servo="servo"
+        )  # note this would be broken in prod
         logger.add(handler.sink)
         return logger
 

--- a/tests/pubsub_test.py
+++ b/tests/pubsub_test.py
@@ -1491,10 +1491,6 @@ class TestMixin:
         else:
             host_object.pubsub_exchange.clear()
 
-        tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-        [task.cancel() for task in tasks]
-        await asyncio.gather(*tasks, return_exceptions=True)
-
     async def test_init_with_pubsub_exchange(self) -> None:
         exchange = servo.pubsub.Exchange()
         obj = HostObject(pubsub_exchange=exchange)

--- a/tests/repeating_test.py
+++ b/tests/repeating_test.py
@@ -18,13 +18,6 @@ class RepeatingConnector(BaseConnector):
         extra = Extra.allow
 
 
-@pytest.fixture(autouse=True)
-async def cleanup_tasks() -> None:
-    yield
-    tasks = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-    [task.cancel() for task in tasks]
-
-
 @pytest.mark.parametrize("every", [0.1, Duration(0.1), "0.1s", "1ms", "1ns"])
 async def test_start_repeating_task(mocker, every):
     connector = RepeatingConnector.construct()

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -1,7 +1,10 @@
 import asyncio
+from contextlib import contextmanager
 import pathlib
 from typing import AsyncGenerator
+import typing
 
+import devtools
 import pytest
 import pytest_mock
 import unittest.mock
@@ -13,8 +16,6 @@ import servo.connectors.prometheus
 import servo.types
 import tests.fake
 import tests.helpers
-
-pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
 
 @pytest.fixture()
@@ -52,12 +53,9 @@ async def assembly_runner(
         await runner.progress_handler.shutdown()
 
 
-@tests.helpers.api_mock
-async def test_assembly_shutdown_with_non_running_servo(
-    assembly_runner: servo.runner.AssemblyRunner,
-):
+@contextmanager
+def patch_event_loop() -> typing.Iterator[asyncio.AbstractEventLoop]:
     event_loop = asyncio.get_event_loop()
-
     # NOTE: using the pytest_mocker fixture for mocking the event loop can cause side effects with pytest-asyncio
     #   (eg. when fixture mocking the `stop` method, the test will run forever).
     #   By using unittest.mock, we can ensure the event_loop is restored before exiting this method
@@ -69,34 +67,58 @@ async def test_assembly_shutdown_with_non_running_servo(
         with unittest.mock.patch.object(event_loop, "run_forever", return_value=None):
             # run_forever no longer blocks causing loop.close() to be called immediately, stop runner from closing it to prevent errors
             with unittest.mock.patch.object(event_loop, "close", return_value=None):
+                yield event_loop
 
-                async def wait_for_servo_running():
-                    while not assembly_runner.assembly.servos[0].is_running:
-                        await asyncio.sleep(0.01)
 
-                try:
-                    assembly_runner.run()
-                except ValueError as e:
-                    if (
-                        "add_signal_handler() can only be called from the main thread"
-                        in str(e)
-                    ):
-                        # https://github.com/pytest-dev/pytest-xdist/issues/620
-                        pytest.xfail("not running in the main thread")
-                    else:
-                        raise
+@pytest.mark.asyncio
+@tests.helpers.api_mock
+async def test_assembly_shutdown_with_non_running_servo(
+    assembly_runner: servo.runner.AssemblyRunner,
+):
+    with patch_event_loop() as event_loop:
 
-                await asyncio.wait_for(wait_for_servo_running(), timeout=2)
+        async def wait_for_servo_running():
+            while not assembly_runner.assembly.servos[0].is_running:
+                await asyncio.sleep(0.01)
 
-                # Shutdown the servo to produce edge case error
-                await assembly_runner.assembly.servos[0].shutdown()
-                try:
-                    await assembly_runner.assembly.shutdown()
-                except:
-                    raise
-                finally:
-                    # Teardown runner asyncio tasks so they don't raise errors when the loop is closed by pytest
-                    await assembly_runner.shutdown(event_loop)
+        try:
+            assembly_runner.run()
+        except ValueError as e:
+            if "add_signal_handler() can only be called from the main thread" in str(e):
+                # https://github.com/pytest-dev/pytest-xdist/issues/620
+                pytest.xfail("not running in the main thread")
+            else:
+                raise
+
+        await asyncio.wait_for(wait_for_servo_running(), timeout=2)
+
+        # Shutdown the servo to produce edge case error
+        await assembly_runner.assembly.servos[0].shutdown()
+        try:
+            await assembly_runner.assembly.shutdown()
+        except:
+            raise
+        finally:
+            # Teardown runner asyncio tasks so they don't raise errors when the loop is closed by pytest
+            await assembly_runner.shutdown(event_loop)
+
+
+@pytest.mark.timeout(5)
+@tests.helpers.api_mock
+def test_assembly_run_raises_task_errors(
+    mocker: pytest_mock.MockerFixture, assembly_runner: servo.runner.AssemblyRunner
+):
+    # with patch_event_loop() as event_loop:
+    mock = mocker.patch.object(servo.runner.ServoRunner, "run_main_loop")
+    mock.side_effect = RuntimeError("KABOOM")
+    with pytest.raises(ExceptionGroup) as eg:
+        assembly_runner.run()
+        # event_loop.run_until_complete(assembly_runner._root_task)
+        print(mock.called)
+
+    assert tests.helpers.unwrap_exception_group(
+        eg.value, RuntimeError, 1
+    ), devtools.pformat(eg.value)
 
 
 @pytest.fixture
@@ -105,6 +127,7 @@ async def servo_runner(assembly: servo.Assembly) -> servo.runner.ServoRunner:
     return servo.runner.ServoRunner(assembly.servos[0])
 
 
+@pytest.mark.asyncio
 @pytest.fixture
 async def running_servo(
     event_loop: asyncio.AbstractEventLoop,
@@ -131,6 +154,7 @@ async def running_servo(
 
 
 # TODO: Switch this over to using a FakeAPI
+@pytest.mark.asyncio
 @pytest.mark.xfail(reason="too brittle.")
 async def test_out_of_order_operations(servo_runner: servo.runner.ServoRunner) -> None:
     await servo_runner.servo.startup()
@@ -169,6 +193,7 @@ async def test_out_of_order_operations(servo_runner: servo.runner.ServoRunner) -
     servo_runner.logger.info("test logging", operation="ADJUST", progress=55)
 
 
+@pytest.mark.asyncio
 async def test_hello(
     servo_runner: servo.runner.ServoRunner,
     fakeapi_url: str,
@@ -226,6 +251,7 @@ async def test_hello(
 #     # fire up runner.run and check .run, etc.
 
 
+@pytest.mark.asyncio
 async def test_authorization_redacted(
     servo_runner: servo.runner.ServoRunner,
     fakeapi_url: str,
@@ -251,6 +277,7 @@ async def test_authorization_redacted(
     assert servo_runner.optimizer.token.get_secret_value() not in curlify_log
 
 
+@pytest.mark.asyncio
 async def test_control_sent_on_adjust(
     servo_runner: servo.runner.ServoRunner,
     fakeapi_url: str,
@@ -287,6 +314,7 @@ async def test_control_sent_on_adjust(
 
 
 # TODO: This doesn't need to be integration test
+@pytest.mark.asyncio
 @tests.helpers.api_mock
 async def test_adjustment_rejected(
     mocker, servo_runner: servo.runner.ServoRunner

--- a/tests/runner_test.py
+++ b/tests/runner_test.py
@@ -26,7 +26,7 @@ async def assembly(servo_yaml: pathlib.Path) -> servo.assembly.Assembly:
     )
     # TODO: This needs a real optimizer ID
     optimizer = servo.configuration.OpsaniOptimizer(
-        id="dev.opsani.com/servox-integration-tests",
+        id="dev.opsani.com/servox",
         token="00000000-0000-0000-0000-000000000000",
     )
     config = config_model.generate(optimizer=optimizer)
@@ -46,6 +46,7 @@ def assembly_runner(assembly: servo.Assembly) -> servo.runner.AssemblyRunner:
     return servo.runner.AssemblyRunner(assembly)
 
 
+@tests.helpers.api_mock
 async def test_assembly_shutdown_with_non_running_servo(
     assembly_runner: servo.runner.AssemblyRunner,
 ):
@@ -86,7 +87,7 @@ async def test_assembly_shutdown_with_non_running_servo(
                 raise
             finally:
                 # Teardown runner asyncio tasks so they don't raise errors when the loop is closed by pytest
-                await assembly_runner._shutdown(event_loop)
+                await assembly_runner.shutdown(event_loop)
 
 
 @pytest.fixture

--- a/tests/servo_test.py
+++ b/tests/servo_test.py
@@ -45,7 +45,7 @@ from servo.events import (
 )
 from servo.servo import Events, Servo
 from servo.types import Control, Description, Measurement
-from tests.helpers import MeasureConnector, environment_overrides
+from tests.helpers import api_mock, MeasureConnector, environment_overrides
 
 
 def test_version():
@@ -404,12 +404,6 @@ async def test_dispatching_multiple_specific_prepositions(mocker, servo: Servo) 
     before_spy.assert_called_once()
     on_spy.assert_called_once()
     after_spy.assert_not_called()
-
-
-api_mock = respx.mock(base_url="https://api.opsani.com/", assert_all_called=True)
-api_mock.post("/accounts/dev.opsani.com/applications/servox/servo", name="servo").mock(
-    return_value=httpx.Response(200, json={"status": "ok"}),
-)
 
 
 @api_mock


### PR DESCRIPTION
- refactor connector initialization to be member method load_connectors of servo instead of procedural assembly logic
- update servo to store connector type routes loaded from config yam/default values
- fix servo attach() and detach() referencing servo module
- refactor servo shutdown to send gootbye event, add reason param to shutdown to include in request
- use TaskGroup for checks rememdy processing to avoid task leaks
- Move AssemblyRunner run() args poll, interactive to class properties set on init
- fix incorrected type hint on _default_context_manager
- Update progress handler to support creating its queue processor task with an external task group tied to lifetime of the AssemblyRunner
- Update progress handler sink to require servo from extra or context and include in progress dict
- alphebetize progress dict by key
- move servo to api connection details from ServoRunner to servo
- Update ServoRunner to utilize a task group to organize tasks that used to be created and stored as properties with additional management boilerplate
- Coallesce main_loop into run_main_loop
- get rid of pointlress _reraise_if_neccessary method cluttering stack trace
- remove hello event logic from run and set it to run in servo.startup()
- fix main_loop_task not set to main loop of ServoRunner
- move goodbye event logic to servo shutdown, call assembly.remove_servo() to send it, use _main_loop_task and _task_group for cleanup and auditing
- Update AssemblyRunner to kick off and store single root task from synchronous invocation
- Move most of run() logic into async version _run()
- Update AssemblyRunner to use two task group for tracking tasks that used to be spawned from create_task without storing any refernces to them
- _task_group contextualizes all tasks run within the AssemblyRunner._run() function to ensure the lifetime of the Progress handler is tied to the lifetime of the running servos and gets cancelled by crash errors thrown by them
- _runners_task_group holds only the servo tasks. Due to the progressHandlers queue_processor running an infinite loop, _task_group would run forever if allowed to. _runners_task_group allows us to determine if all servo runner tasks have completed and gracefully exit the _task_group when that is the case
- move _report_progress from dynamic method to class method
- move _handle_progress_exception from dynamic method to class method
- add AssemblyRunner.shutdown guard for re-entrant shutdown
- Update AssemblyRunner.shutdown to attempt to shutdown gracefully and kill the root_task instead of killing all tasks. This should propagate a cancellation down the chain of task groups this agent is now structured under
- Update _handle_progress_exception to shutdown and restart only the individual servo that threw the error instead of all_tasks. Makes use of previously dead code Assembly.add/remove_servo as well as added task groups
- Update Servo connectors lists init to be self contained
- Fix type hint error warnings caused by DNSSubdomainName, DNSLabelName, ContainerTagName
- Disable unused pubsub startup in prometheus connector
- fix unresolved import errors in IDE for devtools.debug
- Fix captured_logs type hint error
- Fix type hints for minikube fixture
- Use task group for FakeAPI server
- Use task group for kubectl_ports_forwarded
- Remove any remaining logic that clobbers asyncio.all_tasks (only tests left at this point)
- fix servo_test failures
- replace prometheus test tasks with task group